### PR TITLE
 feat(firewall): add discovery service and fix port range normalization

### DIFF
--- a/src/foundation/firewall/firewall.json
+++ b/src/foundation/firewall/firewall.json
@@ -38,6 +38,7 @@
   "provides": [
     "firewall",
     "proxy",
-    "rules"
+    "rules",
+    "discovery"
   ]
 }

--- a/src/foundation/firewall/services/discovery/delete-service.sh
+++ b/src/foundation/firewall/services/discovery/delete-service.sh
@@ -2,13 +2,10 @@
 #
 # TAPPaaS Discovery Service - Delete
 #
-# Removes UDP broadcast relay entries owned by a module (identified by
-# description prefix "tappaas:<module>:"). Reloads the relay service if
-# any entries were removed.
-#
-# mDNS repeater interfaces are NOT automatically cleaned up: they are shared
-# across all modules and removing one module's zone0 could break others.
-# If cleanup is needed, update os-mdns-repeater manually via OPNsense UI.
+# Removes discovery config owned by a module:
+#   - discoveryUdpRelay: deletes relay entries with prefix "tappaas_<module>_"
+#   - discoveryMdns: removes zone0 + consumer zones from os-mdns-repeater,
+#     but only if no other installed module still needs them (shared-interface safety).
 #
 # Usage: delete-service.sh <module-name>
 #
@@ -36,7 +33,7 @@ FIREWALL_TYPE="opnsense"
 [[ -f "${FIREWALL_JSON}" ]] && FIREWALL_TYPE=$(jq -r '.firewallType // "opnsense"' "${FIREWALL_JSON}")
 
 if [[ "${FIREWALL_TYPE}" == "NONE" ]]; then
-    warn "firewallType=NONE — please manually remove any discovery relay configuration for ${MODULE}."
+    warn "firewallType=NONE — please manually remove any discovery configuration for ${MODULE}."
     info "${GN}firewall:discovery delete-service completed for ${MODULE} (manual cleanup required)${CL}"
     exit 0
 fi
@@ -55,7 +52,6 @@ CURL=(-sk -u "${KEY}:${SECRET}")
 
 # ── Remove UDP relay entries owned by this module ────────────────────
 
-# Description format uses underscores (OPNsense DescriptionField rejects hyphens)
 MODULE_SAFE="${MODULE//-/_}"
 DESC_PREFIX="tappaas_${MODULE_SAFE}_"
 
@@ -81,15 +77,137 @@ else
     info "  No UDP relay entries found for module '${MODULE}'."
 fi
 
-# ── mDNS: warn if module used mDNS ──────────────────────────────────
+# ── Remove mDNS repeater interfaces no longer needed ────────────────
+# Only removes interfaces that no other installed module still needs.
 
-HAS_MDNS="false"
-[[ -f "${MODULE_JSON}" ]] && HAS_MDNS=$(jq -r '.discoveryMdns // false' "${MODULE_JSON}")
-if [[ "${HAS_MDNS}" == "true" ]]; then
-    ZONE0=$(jq -r '.zone0 // "unknown"' "${MODULE_JSON}")
-    warn "  mDNS repeater interfaces are shared and NOT automatically removed."
-    warn "  If '${MODULE}' was the last module using zone '${ZONE0}' for mDNS,"
-    warn "  remove it manually: OPNsense → Services → mDNS Repeater."
+if [[ ! -f "${MODULE_JSON}" ]]; then
+    info "  Module config not found — skipping mDNS cleanup."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"
+    exit 0
 fi
+
+MDNS_RAW=$(jq -r '.discoveryMdns // "false"' "${MODULE_JSON}")
+
+if [[ "${MDNS_RAW}" == "false" ]]; then
+    info "  No discoveryMdns declared — skipping mDNS cleanup."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"
+    exit 0
+fi
+
+info "  Checking mDNS repeater cleanup..."
+
+# Collect zones contributed by this module (zone0 + consumer zones)
+THIS_ZONES=()
+ZONE0=$(jq -r '.zone0 // empty' "${MODULE_JSON}")
+[[ -n "${ZONE0}" ]] && THIS_ZONES+=("${ZONE0}")
+if [[ "${MDNS_RAW}" != "true" ]]; then
+    while IFS= read -r zone; do
+        THIS_ZONES+=("${zone}")
+    done < <(jq -r '.discoveryMdns[]' "${MODULE_JSON}")
+fi
+
+if [[ "${#THIS_ZONES[@]}" -eq 0 ]]; then
+    info "  No mDNS zones to clean up."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"
+    exit 0
+fi
+
+# Collect zones still needed by other installed modules
+OTHER_ZONES=()
+for config_file in "${CONFIG_DIR}"/*.json; do
+    other_module=$(basename "${config_file}" .json)
+    [[ "${other_module}" == "${MODULE}" ]] && continue
+
+    other_mdns=$(jq -r '.discoveryMdns // "false"' "${config_file}" 2>/dev/null) || continue
+    [[ "${other_mdns}" == "false" ]] && continue
+
+    other_zone0=$(jq -r '.zone0 // empty' "${config_file}")
+    [[ -n "${other_zone0}" ]] && OTHER_ZONES+=("${other_zone0}")
+
+    if [[ "${other_mdns}" != "true" ]]; then
+        while IFS= read -r zone; do
+            OTHER_ZONES+=("${zone}")
+        done < <(jq -r '.discoveryMdns[]' "${config_file}")
+    fi
+done
+
+# Compute which of this module's zones are safe to remove
+SAFE_TO_REMOVE=()
+for zone in "${THIS_ZONES[@]}"; do
+    needed=false
+    for other_zone in "${OTHER_ZONES[@]}"; do
+        [[ "${zone}" == "${other_zone}" ]] && { needed=true; break; }
+    done
+    if [[ "${needed}" == "false" ]]; then
+        SAFE_TO_REMOVE+=("${zone}")
+    else
+        info "  Zone '${zone}' still needed by another module — keeping."
+    fi
+done
+
+if [[ "${#SAFE_TO_REMOVE[@]}" -eq 0 ]]; then
+    info "  All mDNS zones still needed by other modules — nothing removed."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"
+    exit 0
+fi
+
+# Resolve zone names → OPNsense interface identifiers
+MDNS_RESP=$(curl "${CURL[@]}" "${API}/mdnsrepeater/settings/get")
+if ! echo "${MDNS_RESP}" | jq -e '.mdnsrepeater.interfaces' >/dev/null 2>&1; then
+    warn "  os-mdns-repeater not available — skipping mDNS cleanup."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"
+    exit 0
+fi
+IFACE_JSON=$(echo "${MDNS_RESP}" | jq '.mdnsrepeater.interfaces')
+
+resolve_iface() {
+    local zone="$1"
+    echo "${IFACE_JSON}" | jq -r --arg z "${zone}" \
+        'to_entries[]
+         | select(.value.value | ascii_downcase | startswith(($z | gsub("-";"_") | ascii_downcase)))
+         | .key' \
+        | head -1
+}
+
+REMOVE_IFACES=()
+for zone in "${SAFE_TO_REMOVE[@]}"; do
+    iface=$(resolve_iface "${zone}")
+    if [[ -z "${iface}" ]]; then
+        warn "  Cannot resolve interface for zone '${zone}' — skipping."
+    else
+        REMOVE_IFACES+=("${iface}")
+        info "  Will remove mDNS interface: ${zone} → ${iface}"
+    fi
+done
+
+if [[ "${#REMOVE_IFACES[@]}" -eq 0 ]]; then
+    info "  No mDNS interfaces resolved for removal."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"
+    exit 0
+fi
+
+# Build new interface set: current selected minus the ones to remove
+CURRENT=$(echo "${MDNS_RESP}" | jq -r \
+    '.mdnsrepeater.interfaces | to_entries[] | select(.value.selected == 1) | .key')
+
+NEW_IFACES=""
+while IFS= read -r iface; do
+    [[ -z "${iface}" ]] && continue
+    skip=false
+    for rm_iface in "${REMOVE_IFACES[@]}"; do
+        [[ "${iface}" == "${rm_iface}" ]] && { skip=true; break; }
+    done
+    [[ "${skip}" == "false" ]] && NEW_IFACES="${NEW_IFACES},${iface}"
+done <<< "${CURRENT}"
+NEW_IFACES="${NEW_IFACES#,}"
+
+SAVE_RESP=$(curl "${CURL[@]}" -X POST -H "Content-Type: application/json" \
+    -d "{\"mdnsrepeater\":{\"enabled\":\"1\",\"interfaces\":\"${NEW_IFACES}\"}}" \
+    "${API}/mdnsrepeater/settings/set")
+echo "${SAVE_RESP}" | jq -e '.result == "saved"' >/dev/null \
+    || die "mDNS settings/set failed: ${SAVE_RESP}"
+
+curl "${CURL[@]}" -X POST "${API}/mdnsrepeater/service/reconfigure" >/dev/null
+info "  mDNS repeater updated: removed ${#REMOVE_IFACES[@]} interface(s), reconfigured."
 
 info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"

--- a/src/foundation/firewall/services/discovery/delete-service.sh
+++ b/src/foundation/firewall/services/discovery/delete-service.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS Discovery Service - Delete
+#
+# Removes UDP broadcast relay entries owned by a module (identified by
+# description prefix "tappaas:<module>:"). Reloads the relay service if
+# any entries were removed.
+#
+# mDNS repeater interfaces are NOT automatically cleaned up: they are shared
+# across all modules and removing one module's zone0 could break others.
+# If cleanup is needed, update os-mdns-repeater manually via OPNsense UI.
+#
+# Usage: delete-service.sh <module-name>
+#
+
+set -euo pipefail
+
+# shellcheck source=common-install-routines.sh
+. /home/tappaas/bin/common-install-routines.sh
+
+MODULE="${1:-}"
+if [[ -z "${MODULE}" ]]; then
+    error "Usage: delete-service.sh <module-name>"
+    exit 1
+fi
+
+readonly CONFIG_DIR="/home/tappaas/config"
+readonly MODULE_JSON="${CONFIG_DIR}/${MODULE}.json"
+readonly FIREWALL_JSON="${CONFIG_DIR}/firewall.json"
+
+info "firewall:discovery delete-service for module: ${BL}${MODULE}${CL}"
+
+# ── Check firewallType ───────────────────────────────────────────────
+
+FIREWALL_TYPE="opnsense"
+[[ -f "${FIREWALL_JSON}" ]] && FIREWALL_TYPE=$(jq -r '.firewallType // "opnsense"' "${FIREWALL_JSON}")
+
+if [[ "${FIREWALL_TYPE}" == "NONE" ]]; then
+    warn "firewallType=NONE — please manually remove any discovery relay configuration for ${MODULE}."
+    info "${GN}firewall:discovery delete-service completed for ${MODULE} (manual cleanup required)${CL}"
+    exit 0
+fi
+
+# ── OPNsense API credentials ─────────────────────────────────────────
+
+CREDS_FILE="${HOME}/.opnsense-credentials.txt"
+[[ -f "${CREDS_FILE}" ]] || die "OPNsense credentials not found: ${CREDS_FILE}"
+KEY=$(grep '^key=' "${CREDS_FILE}" | cut -d= -f2-)
+SECRET=$(grep '^secret=' "${CREDS_FILE}" | cut -d= -f2-)
+[[ -z "${KEY}" || -z "${SECRET}" ]] && die "Failed to parse OPNsense credentials"
+
+FW_HOST="${OPNSENSE_HOST:-10.0.0.1}"
+API="https://${FW_HOST}:8443/api"
+CURL=(-sk -u "${KEY}:${SECRET}")
+
+# ── Remove UDP relay entries owned by this module ────────────────────
+
+# Description format uses underscores (OPNsense DescriptionField rejects hyphens)
+MODULE_SAFE="${MODULE//-/_}"
+DESC_PREFIX="tappaas_${MODULE_SAFE}_"
+
+RELAY_ROWS=$(curl "${CURL[@]}" "${API}/udpbroadcastrelay/settings/searchRelay" \
+    | jq -c --arg prefix "${DESC_PREFIX}" \
+        '.rows[] | select(.description | startswith($prefix))')
+
+DELETED=0
+while IFS= read -r row; do
+    [[ -z "${row}" ]] && continue
+    uuid=$(echo "${row}" | jq -r '.uuid')
+    desc=$(echo "${row}" | jq -r '.description')
+    info "  Removing UDP relay: ${desc} (${uuid})"
+    curl "${CURL[@]}" -X POST \
+        "${API}/udpbroadcastrelay/settings/delRelay/${uuid}" >/dev/null
+    (( DELETED++ )) || true
+done <<< "${RELAY_ROWS}"
+
+if (( DELETED > 0 )); then
+    curl "${CURL[@]}" -X POST "${API}/udpbroadcastrelay/service/reload" >/dev/null
+    info "  Removed ${DELETED} UDP relay entry/entries; service reloaded."
+else
+    info "  No UDP relay entries found for module '${MODULE}'."
+fi
+
+# ── mDNS: warn if module used mDNS ──────────────────────────────────
+
+HAS_MDNS="false"
+[[ -f "${MODULE_JSON}" ]] && HAS_MDNS=$(jq -r '.discoveryMdns // false' "${MODULE_JSON}")
+if [[ "${HAS_MDNS}" == "true" ]]; then
+    ZONE0=$(jq -r '.zone0 // "unknown"' "${MODULE_JSON}")
+    warn "  mDNS repeater interfaces are shared and NOT automatically removed."
+    warn "  If '${MODULE}' was the last module using zone '${ZONE0}' for mDNS,"
+    warn "  remove it manually: OPNsense → Services → mDNS Repeater."
+fi
+
+info "${GN}firewall:discovery delete-service completed for ${MODULE}${CL}"

--- a/src/foundation/firewall/services/discovery/install-service.sh
+++ b/src/foundation/firewall/services/discovery/install-service.sh
@@ -35,9 +35,21 @@ info "firewall:discovery install-service for module: ${BL}${MODULE}${CL}"
 
 # ── Read discovery config ────────────────────────────────────────────
 
-HAS_MDNS=$(jq -r '.discoveryMdns // false' "${MODULE_JSON}")
 ZONE0=$(jq -r '.zone0 // empty' "${MODULE_JSON}")
 UDP_RELAY_COUNT=$(jq -r '(.discoveryUdpRelay // []) | length' "${MODULE_JSON}")
+
+# discoveryMdns accepts an array of consumer zone names (e.g. ["home","srv-home"]).
+# Legacy boolean true is still accepted but deprecated — emit a warning and treat as
+# empty consumer list (zone0 is still added; run update-service to migrate).
+MDNS_RAW=$(jq -r '.discoveryMdns // "false"' "${MODULE_JSON}")
+MDNS_ZONES_COUNT=0
+if [[ "${MDNS_RAW}" == "true" ]]; then
+    warn "  discoveryMdns: true is deprecated. Use an array of consumer zones, e.g. [\"home\",\"srv-home\"]."
+    MDNS_ZONES_COUNT=0
+elif [[ "${MDNS_RAW}" != "false" ]]; then
+    MDNS_ZONES_COUNT=$(jq -r '.discoveryMdns | length' "${MODULE_JSON}")
+fi
+HAS_MDNS=$([[ "${MDNS_RAW}" != "false" ]] && echo "true" || echo "false")
 
 if [[ "${HAS_MDNS}" == "false" && "${UDP_RELAY_COUNT}" == "0" ]]; then
     info "  No discoveryMdns or discoveryUdpRelay declared — nothing to apply."
@@ -101,18 +113,25 @@ resolve_iface() {
 # ── mDNS repeater ────────────────────────────────────────────────────
 
 if [[ "${HAS_MDNS}" == "true" ]]; then
-    [[ -z "${ZONE0}" ]] && die "discoveryMdns=true but zone0 not set in ${MODULE_JSON}"
-    info "  Configuring mDNS repeater (zone0=${ZONE0} + home + srv-home)..."
+    [[ -z "${ZONE0}" ]] && die "discoveryMdns set but zone0 not set in ${MODULE_JSON}"
+    info "  Configuring mDNS repeater (zone0=${ZONE0}, consumer zones: ${MDNS_ZONES_COUNT})..."
 
     ZONE0_IFACE=$(resolve_iface "${ZONE0}")
-    HOME_IFACE=$(resolve_iface "home")
-    SRVHOME_IFACE=$(resolve_iface "srv-home")
     [[ -z "${ZONE0_IFACE}" ]] && die "Cannot resolve OPNsense interface for zone: ${ZONE0}"
 
-    # Union current selected interfaces with the new ones (deduplicate)
+    # Resolve each consumer zone declared in discoveryMdns[]
+    CONSUMER_IFACES=""
+    if (( MDNS_ZONES_COUNT > 0 )); then
+        while IFS= read -r zone; do
+            iface=$(resolve_iface "${zone}")
+            [[ -n "${iface}" ]] && CONSUMER_IFACES="${CONSUMER_IFACES} ${iface}"
+        done < <(jq -r '.discoveryMdns[]' "${MODULE_JSON}")
+    fi
+
+    # Union current selected interfaces with zone0 + consumer zones (deduplicate)
     CURRENT=$(echo "${MDNS_RESP}" | jq -r \
         '.mdnsrepeater.interfaces | to_entries[] | select(.value.selected == 1) | .key')
-    ALL_IFACES=$(printf '%s\n' ${CURRENT} "${ZONE0_IFACE}" "${HOME_IFACE}" "${SRVHOME_IFACE}" \
+    ALL_IFACES=$(printf '%s\n' ${CURRENT} "${ZONE0_IFACE}" ${CONSUMER_IFACES} \
         | grep -v '^$' | sort -u | tr '\n' ',' | sed 's/,$//')
 
     info "  mDNS interfaces set: ${BL}${ALL_IFACES}${CL}"

--- a/src/foundation/firewall/services/discovery/install-service.sh
+++ b/src/foundation/firewall/services/discovery/install-service.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS Discovery Service - Install
+#
+# Configures cross-VLAN discovery on OPNsense for a consuming module:
+#   - discoveryMdns: true  → adds zone0 + home + srv-home to os-mdns-repeater
+#   - discoveryUdpRelay[]  → adds per-port relay instances to os-udpbroadcastrelay
+#
+# Both operations are idempotent: mDNS uses GET→union→SET, UDP relay checks
+# description "tappaas:<module>:<port>" before adding.
+#
+# When firewallType is "NONE", prints manual instructions and exits 0.
+#
+# Usage: install-service.sh <module-name>
+#
+
+set -euo pipefail
+
+# shellcheck source=common-install-routines.sh
+. /home/tappaas/bin/common-install-routines.sh
+
+MODULE="${1:-}"
+if [[ -z "${MODULE}" ]]; then
+    error "Usage: install-service.sh <module-name>"
+    exit 1
+fi
+
+readonly CONFIG_DIR="/home/tappaas/config"
+readonly MODULE_JSON="${CONFIG_DIR}/${MODULE}.json"
+readonly FIREWALL_JSON="${CONFIG_DIR}/firewall.json"
+
+info "firewall:discovery install-service for module: ${BL}${MODULE}${CL}"
+
+[[ -f "${MODULE_JSON}" ]] || die "Module config not found: ${MODULE_JSON}"
+
+# ── Read discovery config ────────────────────────────────────────────
+
+HAS_MDNS=$(jq -r '.discoveryMdns // false' "${MODULE_JSON}")
+ZONE0=$(jq -r '.zone0 // empty' "${MODULE_JSON}")
+UDP_RELAY_COUNT=$(jq -r '(.discoveryUdpRelay // []) | length' "${MODULE_JSON}")
+
+if [[ "${HAS_MDNS}" == "false" && "${UDP_RELAY_COUNT}" == "0" ]]; then
+    info "  No discoveryMdns or discoveryUdpRelay declared — nothing to apply."
+    info "${GN}firewall:discovery install-service completed for ${MODULE} (no-op)${CL}"
+    exit 0
+fi
+
+# ── Check firewallType ───────────────────────────────────────────────
+
+FIREWALL_TYPE="opnsense"
+[[ -f "${FIREWALL_JSON}" ]] && FIREWALL_TYPE=$(jq -r '.firewallType // "opnsense"' "${FIREWALL_JSON}")
+
+if [[ "${FIREWALL_TYPE}" == "NONE" ]]; then
+    warn "firewallType=NONE — manual configuration required:"
+    if [[ "${HAS_MDNS}" == "true" ]]; then
+        warn "  Install os-mdns-repeater; add interfaces for zones: ${ZONE0}, home, srv-home"
+    fi
+    if (( UDP_RELAY_COUNT > 0 )); then
+        jq -r '.discoveryUdpRelay[]? |
+            "  Install os-udpbroadcastrelay; UDP relay port \(.port) for zones: \(.zones | join(", "))"' \
+            "${MODULE_JSON}"
+    fi
+    info "${GN}firewall:discovery install-service completed for ${MODULE} (manual config required)${CL}"
+    exit 0
+fi
+
+# ── OPNsense API credentials ─────────────────────────────────────────
+
+CREDS_FILE="${HOME}/.opnsense-credentials.txt"
+[[ -f "${CREDS_FILE}" ]] || die "OPNsense credentials not found: ${CREDS_FILE}"
+KEY=$(grep '^key=' "${CREDS_FILE}" | cut -d= -f2-)
+SECRET=$(grep '^secret=' "${CREDS_FILE}" | cut -d= -f2-)
+[[ -z "${KEY}" || -z "${SECRET}" ]] && die "Failed to parse OPNsense credentials"
+
+FW_HOST="${OPNSENSE_HOST:-10.0.0.1}"
+API="https://${FW_HOST}:8443/api"
+CURL=(-sk -u "${KEY}:${SECRET}")
+
+# ── Fetch mDNS interface map ─────────────────────────────────────────
+# Used for zone-name → OPNsense interface-id resolution (e.g. iot-cloud → opt21).
+# mDNS GET returns all available interfaces; we parse the value strings.
+# If the endpoint returns an error, os-mdns-repeater is not installed.
+
+MDNS_RESP=$(curl "${CURL[@]}" "${API}/mdnsrepeater/settings/get")
+if ! echo "${MDNS_RESP}" | jq -e '.mdnsrepeater.interfaces' >/dev/null 2>&1; then
+    die "os-mdns-repeater plugin not available (API returned: ${MDNS_RESP}). Install it via OPNsense > System > Firmware > Plugins."
+fi
+IFACE_JSON=$(echo "${MDNS_RESP}" | jq '.mdnsrepeater.interfaces')
+
+resolve_iface() {
+    # OPNsense interface labels use underscores: "iot_cloud", "srv_home".
+    # Zone names use hyphens: "iot-cloud", "srv-home". Normalise before matching.
+    local zone="$1"
+    echo "${IFACE_JSON}" | jq -r --arg z "${zone}" \
+        'to_entries[]
+         | select(.value.value | ascii_downcase | startswith(($z | gsub("-";"_") | ascii_downcase)))
+         | .key' \
+        | head -1
+}
+
+# ── mDNS repeater ────────────────────────────────────────────────────
+
+if [[ "${HAS_MDNS}" == "true" ]]; then
+    [[ -z "${ZONE0}" ]] && die "discoveryMdns=true but zone0 not set in ${MODULE_JSON}"
+    info "  Configuring mDNS repeater (zone0=${ZONE0} + home + srv-home)..."
+
+    ZONE0_IFACE=$(resolve_iface "${ZONE0}")
+    HOME_IFACE=$(resolve_iface "home")
+    SRVHOME_IFACE=$(resolve_iface "srv-home")
+    [[ -z "${ZONE0_IFACE}" ]] && die "Cannot resolve OPNsense interface for zone: ${ZONE0}"
+
+    # Union current selected interfaces with the new ones (deduplicate)
+    CURRENT=$(echo "${MDNS_RESP}" | jq -r \
+        '.mdnsrepeater.interfaces | to_entries[] | select(.value.selected == 1) | .key')
+    ALL_IFACES=$(printf '%s\n' ${CURRENT} "${ZONE0_IFACE}" "${HOME_IFACE}" "${SRVHOME_IFACE}" \
+        | grep -v '^$' | sort -u | tr '\n' ',' | sed 's/,$//')
+
+    info "  mDNS interfaces set: ${BL}${ALL_IFACES}${CL}"
+
+    SAVE_RESP=$(curl "${CURL[@]}" -X POST -H "Content-Type: application/json" \
+        -d "{\"mdnsrepeater\":{\"enabled\":\"1\",\"interfaces\":\"${ALL_IFACES}\"}}" \
+        "${API}/mdnsrepeater/settings/set")
+    echo "${SAVE_RESP}" | jq -e '.result == "saved"' >/dev/null \
+        || die "mDNS settings/set failed: ${SAVE_RESP}"
+
+    # reconfigure rebuilds the configd config file from config.xml and starts/restarts the daemon.
+    # service/restart alone does not rebuild the config and leaves the daemon stopped.
+    curl "${CURL[@]}" -X POST "${API}/mdnsrepeater/service/reconfigure" >/dev/null
+    info "  mDNS repeater reconfigured and started."
+fi
+
+# ── UDP broadcast relay ──────────────────────────────────────────────
+
+if (( UDP_RELAY_COUNT > 0 )); then
+    info "  Configuring UDP broadcast relay (${UDP_RELAY_COUNT} entries)..."
+
+    RELAY_SEARCH=$(curl "${CURL[@]}" "${API}/udpbroadcastrelay/settings/searchRelay")
+    EXISTING_DESCS=$(echo "${RELAY_SEARCH}" | jq -r '.rows[].description // ""')
+
+    # OPNsense DescriptionField rejects hyphens; use underscores throughout.
+    # InstanceID must be unique integer 1-63; find the next available one.
+    MODULE_SAFE="${MODULE//-/_}"
+
+    next_instance_id() {
+        local used_ids
+        used_ids=$(echo "${RELAY_SEARCH}" | jq -r '[.rows[].InstanceID | tonumber] | sort[]' 2>/dev/null || echo "")
+        for i in $(seq 1 63); do
+            if ! echo "${used_ids}" | grep -qx "${i}"; then
+                echo "${i}"
+                return
+            fi
+        done
+        die "All 63 InstanceID slots are in use for os-udpbroadcastrelay"
+    }
+
+    RELAY_ADDED=0
+    while IFS= read -r entry; do
+        PORT=$(echo "${entry}" | jq -r '.port')
+        # Description: underscores only (OPNsense DescriptionField rejects hyphens)
+        DESC="tappaas_${MODULE_SAFE}_${PORT}"
+
+        if echo "${EXISTING_DESCS}" | grep -qF "${DESC}"; then
+            info "  UDP relay port ${PORT} (${DESC}) already configured — skipping."
+            continue
+        fi
+
+        # Resolve each zone to its OPNsense interface identifier
+        ZONE_IFACES=""
+        while IFS= read -r zone; do
+            iface=$(resolve_iface "${zone}")
+            if [[ -z "${iface}" ]]; then
+                warn "  Cannot resolve interface for zone '${zone}' — skipping."
+                continue
+            fi
+            ZONE_IFACES="${ZONE_IFACES},${iface}"
+        done < <(echo "${entry}" | jq -r '.zones[]')
+        ZONE_IFACES="${ZONE_IFACES#,}"
+
+        [[ -z "${ZONE_IFACES}" ]] && die "No valid interfaces resolved for UDP relay port ${PORT}"
+
+        INSTANCE_ID=$(next_instance_id)
+        info "  Adding UDP relay: port=${PORT} ifaces=${ZONE_IFACES} id=${INSTANCE_ID} desc=${DESC}"
+
+        ADD_RESP=$(curl "${CURL[@]}" -X POST -H "Content-Type: application/json" \
+            -d "{\"udpbroadcastrelay\":{\"enabled\":\"1\",\"listenport\":\"${PORT}\",\"interfaces\":\"${ZONE_IFACES}\",\"InstanceID\":\"${INSTANCE_ID}\",\"description\":\"${DESC}\"}}" \
+            "${API}/udpbroadcastrelay/settings/addRelay")
+        echo "${ADD_RESP}" | jq -e '.result == "OK"' >/dev/null \
+            || die "UDP relay addRelay failed: ${ADD_RESP}"
+
+        # Update RELAY_SEARCH to reflect the new entry for next_instance_id
+        RELAY_SEARCH=$(curl "${CURL[@]}" "${API}/udpbroadcastrelay/settings/searchRelay")
+        (( RELAY_ADDED++ )) || true
+    done < <(jq -c '.discoveryUdpRelay[]' "${MODULE_JSON}")
+
+    if (( RELAY_ADDED > 0 )); then
+        info "  UDP broadcast relay reloaded (${RELAY_ADDED} new entries added)."
+    fi
+fi
+
+info "${GN}firewall:discovery install-service completed for ${MODULE}${CL}"

--- a/src/foundation/firewall/services/discovery/test-service.sh
+++ b/src/foundation/firewall/services/discovery/test-service.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS Discovery Service - Test
+#
+# Verifies that every discovery entry declared in a module's JSON is present
+# in OPNsense:
+#   - discoveryMdns: zone0 + each consumer zone is in os-mdns-repeater
+#   - discoveryUdpRelay: each port has a relay entry in os-udpbroadcastrelay
+#
+# Returns non-zero on drift (declared but missing in OPNsense).
+#
+# Usage: test-service.sh <module-name>
+#
+
+set -euo pipefail
+
+# shellcheck source=common-install-routines.sh
+. /home/tappaas/bin/common-install-routines.sh
+
+MODULE="${1:-}"
+if [[ -z "${MODULE}" ]]; then
+    error "Usage: test-service.sh <module-name>"
+    exit 1
+fi
+
+readonly CONFIG_DIR="/home/tappaas/config"
+readonly MODULE_JSON="${CONFIG_DIR}/${MODULE}.json"
+readonly FIREWALL_JSON="${CONFIG_DIR}/firewall.json"
+
+info "firewall:discovery test-service for module: ${BL}${MODULE}${CL}"
+
+[[ -f "${MODULE_JSON}" ]] || die "Module config not found: ${MODULE_JSON}"
+
+# ── Read discovery config ────────────────────────────────────────────
+
+ZONE0=$(jq -r '.zone0 // empty' "${MODULE_JSON}")
+UDP_RELAY_COUNT=$(jq -r '(.discoveryUdpRelay // []) | length' "${MODULE_JSON}")
+
+MDNS_RAW=$(jq -r '.discoveryMdns // "false"' "${MODULE_JSON}")
+HAS_MDNS="false"
+MDNS_ZONES_COUNT=0
+if [[ "${MDNS_RAW}" == "true" ]]; then
+    HAS_MDNS="true"
+    MDNS_ZONES_COUNT=0
+elif [[ "${MDNS_RAW}" != "false" ]]; then
+    HAS_MDNS="true"
+    MDNS_ZONES_COUNT=$(jq -r '.discoveryMdns | length' "${MODULE_JSON}")
+fi
+
+if [[ "${HAS_MDNS}" == "false" && "${UDP_RELAY_COUNT}" == "0" ]]; then
+    info "  No discoveryMdns or discoveryUdpRelay declared — nothing to verify."
+    info "${GN}firewall:discovery test-service completed for ${MODULE} (no-op)${CL}"
+    exit 0
+fi
+
+# ── firewallType ─────────────────────────────────────────────────────
+
+FIREWALL_TYPE="opnsense"
+[[ -f "${FIREWALL_JSON}" ]] && FIREWALL_TYPE=$(jq -r '.firewallType // "opnsense"' "${FIREWALL_JSON}")
+
+if [[ "${FIREWALL_TYPE}" == "NONE" ]]; then
+    info "  firewallType=NONE — no automated discovery to verify."
+    info "${GN}firewall:discovery test-service completed for ${MODULE} (skipped)${CL}"
+    exit 0
+fi
+
+# ── OPNsense API credentials ─────────────────────────────────────────
+
+CREDS_FILE="${HOME}/.opnsense-credentials.txt"
+[[ -f "${CREDS_FILE}" ]] || die "OPNsense credentials not found: ${CREDS_FILE}"
+KEY=$(grep '^key=' "${CREDS_FILE}" | cut -d= -f2-)
+SECRET=$(grep '^secret=' "${CREDS_FILE}" | cut -d= -f2-)
+[[ -z "${KEY}" || -z "${SECRET}" ]] && die "Failed to parse OPNsense credentials"
+
+FW_HOST="${OPNSENSE_HOST:-10.0.0.1}"
+API="https://${FW_HOST}:8443/api"
+CURL=(-sk -u "${KEY}:${SECRET}")
+
+FAILURES=0
+
+# ── Helper: resolve zone name → OPNsense interface id ───────────────
+
+resolve_iface() {
+    local zone="$1"
+    echo "${IFACE_JSON}" | jq -r --arg z "${zone}" \
+        'to_entries[]
+         | select(.value.value | ascii_downcase | startswith(($z | gsub("-";"_") | ascii_downcase)))
+         | .key' \
+        | head -1
+}
+
+# ── Test: mDNS repeater ──────────────────────────────────────────────
+
+if [[ "${HAS_MDNS}" == "true" ]]; then
+    info "  Checking mDNS repeater..."
+
+    MDNS_RESP=$(curl "${CURL[@]}" "${API}/mdnsrepeater/settings/get")
+    if ! echo "${MDNS_RESP}" | jq -e '.mdnsrepeater.interfaces' >/dev/null 2>&1; then
+        error "  os-mdns-repeater plugin not available."
+        (( FAILURES++ )) || true
+    else
+        IFACE_JSON=$(echo "${MDNS_RESP}" | jq '.mdnsrepeater.interfaces')
+
+        # zone0 must always be present
+        ZONE0_IFACE=$(resolve_iface "${ZONE0}")
+        if [[ -z "${ZONE0_IFACE}" ]]; then
+            error "  Cannot resolve interface for zone0=${ZONE0}"
+            (( FAILURES++ )) || true
+        else
+            SELECTED=$(echo "${MDNS_RESP}" | jq -r \
+                --arg iface "${ZONE0_IFACE}" \
+                '.mdnsrepeater.interfaces[$iface].selected // 0')
+            if [[ "${SELECTED}" == "1" ]]; then
+                info "  mDNS zone0 (${ZONE0} → ${ZONE0_IFACE}): ${GN}present${CL}"
+            else
+                error "  mDNS zone0 (${ZONE0} → ${ZONE0_IFACE}): ${RD}MISSING${CL}"
+                (( FAILURES++ )) || true
+            fi
+        fi
+
+        # each declared consumer zone must be present
+        if (( MDNS_ZONES_COUNT > 0 )); then
+            while IFS= read -r zone; do
+                iface=$(resolve_iface "${zone}")
+                if [[ -z "${iface}" ]]; then
+                    error "  Cannot resolve interface for consumer zone=${zone}"
+                    (( FAILURES++ )) || true
+                    continue
+                fi
+                selected=$(echo "${MDNS_RESP}" | jq -r \
+                    --arg iface "${iface}" \
+                    '.mdnsrepeater.interfaces[$iface].selected // 0')
+                if [[ "${selected}" == "1" ]]; then
+                    info "  mDNS consumer zone (${zone} → ${iface}): ${GN}present${CL}"
+                else
+                    error "  mDNS consumer zone (${zone} → ${iface}): ${RD}MISSING${CL}"
+                    (( FAILURES++ )) || true
+                fi
+            done < <(jq -r '.discoveryMdns[]' "${MODULE_JSON}")
+        fi
+    fi
+fi
+
+# ── Test: UDP broadcast relay ────────────────────────────────────────
+
+if (( UDP_RELAY_COUNT > 0 )); then
+    info "  Checking UDP broadcast relay..."
+
+    MODULE_SAFE="${MODULE//-/_}"
+    RELAY_SEARCH=$(curl "${CURL[@]}" "${API}/udpbroadcastrelay/settings/searchRelay")
+    EXISTING_DESCS=$(echo "${RELAY_SEARCH}" | jq -r '.rows[].description // ""')
+
+    while IFS= read -r entry; do
+        PORT=$(echo "${entry}" | jq -r '.port')
+        DESC="tappaas_${MODULE_SAFE}_${PORT}"
+        if echo "${EXISTING_DESCS}" | grep -qF "${DESC}"; then
+            info "  UDP relay port ${PORT} (${DESC}): ${GN}present${CL}"
+        else
+            error "  UDP relay port ${PORT} (${DESC}): ${RD}MISSING${CL}"
+            (( FAILURES++ )) || true
+        fi
+    done < <(jq -c '.discoveryUdpRelay[]' "${MODULE_JSON}")
+fi
+
+# ── Result ───────────────────────────────────────────────────────────
+
+if (( FAILURES == 0 )); then
+    info "${GN}firewall:discovery test-service passed for ${MODULE}${CL}"
+    exit 0
+else
+    error "${RD}firewall:discovery test-service detected ${FAILURES} drift(s) for ${MODULE}${CL}"
+    exit 1
+fi

--- a/src/foundation/firewall/services/discovery/update-service.sh
+++ b/src/foundation/firewall/services/discovery/update-service.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS Discovery Service - Update
+#
+# Idempotent re-apply of cross-VLAN discovery configuration.
+# Identical to install-service.sh: mDNS uses GET→union→SET so re-running
+# is always safe. UDP relay checks description before adding.
+#
+# Usage: update-service.sh <module-name>
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/install-service.sh" "$@"

--- a/src/foundation/firewall/zones.json
+++ b/src/foundation/firewall/zones.json
@@ -34,7 +34,7 @@
         "vlantag": 210,
         "ip": "10.2.10.0/24",
         "bridge": "lan",
-        "access-to": ["internet"],
+        "access-to": ["internet", "iot-cloud", "iot-local"],
         "pinhole-allowed-from": [],
         "_comment": "Personal/household services (Home Assistant, personal stack). home/work reach this via their own access-to; mgmt via its access-to.",
         "description": "Personal services: home automation, personal apps"
@@ -90,7 +90,7 @@
         "SSID": "<HOME_SSID>",
         "ip": "10.3.10.0/24",
         "bridge": "lan",
-        "access-to": ["internet", "srv-home", "srv-work"],
+        "access-to": ["internet", "srv-home", "srv-work", "iot-cloud", "iot-local"],
         "pinhole-allowed-from": [],
         "description": "Trusted personal/staff-personal devices: laptops, phones, tablets"
     },

--- a/src/foundation/module-fields.json
+++ b/src/foundation/module-fields.json
@@ -15,6 +15,7 @@
         "bridge0", "mac0", "zone0", "trunks0",
         "bridge1", "mac1", "zone1", "trunks1",
         "firewallType", "aliasType", "proxyDomain", "proxyPort", "proxyUpstreamTls", "proxyTls", "proxyAllowedZones",
+        "discoveryMdns", "discoveryUdpRelay",
         "ports", "ingress", "egress", "aliases",
         "dependsOn", "provides"
     ],
@@ -562,6 +563,42 @@
             "items": "string",
             "example": ["mgmt", "home", "work", "srv-home", "srv-work"],
             "note": "Zero-trust by default: when omitted, a service is reachable only from the internal trusted zones, never the internet. Add 'internet' to publish it publicly (no restriction). Zone names are resolved to subnets via zones.json. Changing this re-applies on the next install/update of the module."
+        },
+
+        "discoveryMdns": {
+            "description": "Bridge zone0 into the global mDNS repeater (os-mdns-repeater). home and srv-home are always included as consumer zones.",
+            "type": "boolean",
+            "requiredBy": [],
+            "usedBy": ["firewall:discovery"],
+            "default": false,
+            "example": true,
+            "note": "Requires firewall:discovery in dependsOn. Installs os-mdns-repeater if absent and idempotently unions zone0+home+srv-home into the repeater interface list."
+        },
+
+        "discoveryUdpRelay": {
+            "description": "UDP broadcast relay instances via os-udpbroadcastrelay. Each entry creates one relay identified by 'tappaas:<module>:<port>'.",
+            "type": "array",
+            "requiredBy": [],
+            "usedBy": ["firewall:discovery"],
+            "default": [],
+            "items": {
+                "type": "object",
+                "fields": {
+                    "port": {
+                        "description": "UDP port to relay (e.g. 36549 for Alfen Nucleus discovery).",
+                        "type": "integer",
+                        "required": true
+                    },
+                    "zones": {
+                        "description": "Zone names whose interfaces receive the relayed broadcast.",
+                        "type": "array",
+                        "items": "string",
+                        "required": true
+                    }
+                }
+            },
+            "example": [{"port": 36549, "zones": ["home", "iot-cloud"]}],
+            "note": "Requires firewall:discovery in dependsOn. Idempotent: checks description before adding. Reload is triggered only when new entries are added."
         },
 
         "ports": {

--- a/src/foundation/module-fields.json
+++ b/src/foundation/module-fields.json
@@ -566,13 +566,14 @@
         },
 
         "discoveryMdns": {
-            "description": "Bridge zone0 into the global mDNS repeater (os-mdns-repeater). home and srv-home are always included as consumer zones.",
-            "type": "boolean",
+            "description": "Consumer zones to bridge with zone0 in the mDNS repeater (os-mdns-repeater). zone0 is always included as the provider zone.",
+            "type": "array",
+            "items": "string",
             "requiredBy": [],
             "usedBy": ["firewall:discovery"],
-            "default": false,
-            "example": true,
-            "note": "Requires firewall:discovery in dependsOn. Installs os-mdns-repeater if absent and idempotently unions zone0+home+srv-home into the repeater interface list."
+            "default": [],
+            "example": ["home", "srv-home"],
+            "note": "Requires firewall:discovery in dependsOn. Idempotently unions zone0 + declared consumer zones into the repeater interface list. Boolean true is deprecated."
         },
 
         "discoveryUdpRelay": {

--- a/src/foundation/tappaas-cicd/opnsense-controller/src/opnsense_controller/rules_manager.py
+++ b/src/foundation/tappaas-cicd/opnsense-controller/src/opnsense_controller/rules_manager.py
@@ -220,7 +220,7 @@ def _normalize_protocol(value: str | None) -> str:
 
 
 def _port_to_str(value: int | str) -> str:
-    return str(value)
+    return str(value).replace(":", "-")
 
 
 def _canonical_description(
@@ -863,7 +863,7 @@ class RulesManager:
 
     def _validate(self, module: ModuleSpec) -> list[ValidationError]:
         errors: list[ValidationError] = []
-        declared_ports = {str(p.get("port")) for p in module.ports}
+        declared_ports = {str(p.get("port")).replace(":", "-") for p in module.ports}
 
         # aliasType must be a recognised value, and "network" needs a zone0 subnet
         # to derive the alias content from (#241).
@@ -939,7 +939,7 @@ class RulesManager:
             # Port consistency: every ingress.ports must be in module.ports[]
             if declared_ports:
                 for port in entry.get("ports", []):
-                    if str(port) not in declared_ports:
+                    if str(port).replace(":", "-") not in declared_ports:
                         errors.append(
                             ValidationError(
                                 module.vmname,


### PR DESCRIPTION
  ## Summary

  - **New**: `firewall:discovery` service — declarative cross-VLAN mDNS repeater and UDP
    broadcast relay via `discoveryMdns` / `discoveryUdpRelay` module fields. Idempotent.
  - **New**: `discoveryMdns` accepts zone array (`["home", "srv-home"]`); boolean `true`
    still accepted with deprecation warning. `module-fields.json` updated accordingly.
  - **New**: `test-service.sh` for `firewall:discovery` — verifies declared mDNS zones and
    UDP relay entries against live OPNsense state.
  - **Fix**: `delete-service.sh` now removes mDNS interfaces on module delete. Safely: scans
    all other installed modules and only removes zones no other module still needs.
  - **Fix**: `rules_manager._port_to_str` normalises colon port ranges to dash
    (`7000:7100` → `7000-7100`) before OPNsense API call. Same normalisation in
    `_validate_declared_ports` check.
  - **Config**: `home` and `srv-home` `access-to` extended with `iot-cloud` and `iot-local`.

  ## Related issues

  Closes #240
  Closes #242

  ## Test plan

  - [x] `sonos-fleet discoveryMdns: true` — Sonos app finds speakers from home WiFi
  - [x] `alfen discoveryUdpRelay port 36549` — MyEve app finds charger from home WiFi
  - [x] `rules-manager add-rules homeassistant` — 23 rules applied, no regression
  - [x] `rules-manager add-rules sonos-fleet` — colon ranges accepted by OPNsense API
  - [x] `delete-service.sh` — UDP relay removed; mDNS interfaces removed only if no other
    module needs them; idempotent no-op if zones are shared
  - [ ] Nix rebuild `opnsense-controller` — needed to ship `rules_manager.py` fix to binary

  ## Not in this PR

  - Outbound NAT masquerade — implemented at module level (`alfen:nat`), not as foundation
    service (design decision, see issue)
  - Sonos fleet `aliasType` gap — addressed upstream in #241
  - `zone-manager` sequence conflict fix — separate PR
  - `homeassistant.json` `dependsOn` stubs — wait for module testing