### PR TITLE
Add tmux to tappaas-cicd baseline packages (#249)

### DIFF
--- a/src/foundation/tappaas-cicd/tappaas-cicd.nix
+++ b/src/foundation/tappaas-cicd/tappaas-cicd.nix
@@ -225,6 +225,7 @@ in
         wget
         curl
         htop
+        tmux        # persistent sessions for long-running ops over SSH
         jq
         git
         gh          # GitHub CLI


### PR DESCRIPTION
## Summary

Adds `tmux` to `environment.systemPackages` in `tappaas-cicd.nix` so SSH sessions on the cicd-VM survive disconnects during long-running operations (module installs, `opnsense-controller` runs).

## Change

- Single line: `tmux` added to the baseline package set, alongside `htop`, `gh`, `jq`, `dig`, etc.
- Packages-only — no service changes, no ports, no security surface change.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)