### PR TITLE
fix(rules-manager): read Pattern A ingress/ports/egress fields in load_module

### DIFF
--- a/src/foundation/tappaas-cicd/opnsense-controller/src/opnsense_controller/rules_manager.py
+++ b/src/foundation/tappaas-cicd/opnsense-controller/src/opnsense_controller/rules_manager.py
@@ -330,14 +330,17 @@ def load_module(modules_dir: Path, name: str) -> ModuleSpec:
         raise FileNotFoundError(f"module config not found: {path}")
     with open(path) as f:
         data = json.load(f)
+    # Pattern A (#207) nests firewall:rules fields under config."firewall:rules".
+    # Fall back to nested form when the top-level key is absent or empty.
+    fr = data.get("config", {}).get("firewall:rules", {})
     return ModuleSpec(
         vmname=data.get("vmname", name),
         zone0=data.get("zone0", ""),
         bridge0=data.get("bridge0", "lan"),
-        ports=data.get("ports", []) or [],
-        ingress=data.get("ingress", []) or [],
-        egress=data.get("egress", []) or [],
-        aliases=data.get("aliases", {}) or {},
+        ports=data.get("ports") or fr.get("ports") or [],
+        ingress=data.get("ingress") or fr.get("ingress") or [],
+        egress=data.get("egress") or fr.get("egress") or [],
+        aliases=data.get("aliases") or fr.get("aliases") or {},
         firewall_type=data.get("firewallType", "opnsense"),
         alias_type=data.get("aliasType", "host") or "host",
         depends_on=data.get("dependsOn", []) or [],


### PR DESCRIPTION
```markdown
## Summary

`rules_manager.py` → `load_module` reads `ingress`, `ports`, and `egress` from the
top-level JSON only. Pattern A (#207) stores these under
`config."firewall:rules".<field>`. Any module using Pattern A is loaded with
`desired=0` rules, causing:

- **`verify-rules`** (test-service): existing OPNsense rules flagged as extra drift →
  test fails → `update-tappaas` aborts all dependent modules (27 of 36 in the
  2026-05-31 run)
- **`apply-rules`** (update-service): installs zero rules for Pattern A modules

## Change

`src/foundation/tappaas-cicd/opnsense-controller/src/opnsense_controller/rules_manager.py`

`load_module` now falls back to `config."firewall:rules".*` when the top-level field
is absent or empty:

```python
fr = data.get("config", {}).get("firewall:rules", {})
ports   = data.get("ports")   or fr.get("ports")   or []
ingress = data.get("ingress") or fr.get("ingress") or []
egress  = data.get("egress")  or fr.get("egress")  or []
aliases = data.get("aliases") or fr.get("aliases") or {}
```

Flat-format modules are unaffected (top-level value takes precedence).

## Test plan

- [ ] `rules-manager verify-rules alfen` — `desired=3`, no extra/missing drift
- [ ] `update-tappaas` — no cascade failure on `firewall:rules` test-service
- [ ] Flat-format module (pre-#207) — behaviour unchanged

## Issues

Closes #268

🤖 Generated with help of [Claude Code]
```