### PR TITLE
feat(install-module): validate zone0 is Active before provisioning

### DIFF
--- a/src/foundation/tappaas-cicd/scripts/common-install-routines.sh
+++ b/src/foundation/tappaas-cicd/scripts/common-install-routines.sh
@@ -337,6 +337,44 @@ validate_provided_services() {
     return "${errors}"
 }
 
+# Validate that the module's zone0 is Active in zones.json.
+# Early-exit guard: called before any provisioning action in install-module.sh.
+# Arguments:
+#   $1  zone name (e.g. srv_work)
+# Returns 1 if zone is missing or not Active; 0 if Active or zones.json absent.
+validate_zone_active() {
+    local zone="$1"
+    local zones_file="${CONFIG_DIR}/zones.json"
+    local state
+
+    if [[ ! -f "$zones_file" ]]; then
+        warn "zones.json not found at $zones_file — skipping zone state check"
+        return 0
+    fi
+
+    if ! jq -e --arg z "$zone" 'has($z)' "$zones_file" > /dev/null 2>&1; then
+        error "Zone '${YW}${zone}${CL}' not found in zones.json"
+        return 1
+    fi
+
+    state=$(jq -r --arg z "$zone" '.[$z].state // "unknown"' "$zones_file")
+
+    if [[ "$state" != "Active" ]]; then
+        error "Zone '${YW}${zone}${CL}' is ${YW}${state}${CL} — cannot deploy module before zone is activated"
+        error ""
+        error "  Options:"
+        error "    1. Activate the zone (upstream PR + Lars review required):"
+        error "         zone-state.sh ${zone} Active"
+        error "         zone-manager --execute"
+        error "    2. Redeploy to an already-active zone:"
+        error "         install-module.sh <module> --zone0 <active-zone>"
+        return 1
+    fi
+
+    info "  ${GN}✓${CL} Zone '${zone}' is Active"
+    return 0
+}
+
 # ── Module-config normalization (#161 / #207) ────────────────────────
 # Defined here (before auto-load) so the auto-load block below can call it.
 # A module JSON may group per-service configuration under a Pattern-A `config`

--- a/src/foundation/tappaas-cicd/scripts/install-module.sh
+++ b/src/foundation/tappaas-cicd/scripts/install-module.sh
@@ -153,18 +153,24 @@ main() {
 
     local module_json="${CONFIG_DIR}/${effective_module}.json"
 
+    local zone0
+    zone0=$(jq -r '.zone0 // empty' "${module_json}")
+    if [[ -n "$zone0" ]]; then
+        validate_zone_active "$zone0" || die "Zone validation failed — install aborted before any resources were created"
+    fi
+
     # ── Step 3: Validate dependencies ────────────────────────────────
     echo ""
     info "${BOLD}Step 3: Validate dependencies${CL}"
 
     local depends_on
-    depends_on=$(read_module_config "${module}" | jq -r '.dependsOn // [] | .[]' 2>/dev/null)
+    depends_on=$(read_module_config "${effective_module}" | jq -r '.dependsOn // [] | .[]' 2>/dev/null)
 
     # A module is either VM-backed or container-backed, never both (issue #203).
-    if read_module_config "${module}" | jq -e '(.dependsOn // []) as $d
+    if read_module_config "${effective_module}" | jq -e '(.dependsOn // []) as $d
               | (($d | index("cluster:vm")) != null)
                 and (($d | index("cluster:lxc")) != null)' >/dev/null 2>&1; then
-        die "Module '${module}' declares both cluster:vm and cluster:lxc in dependsOn — choose one (a guest is a VM or a container, not both)"
+        die "Module '${effective_module}' declares both cluster:vm and cluster:lxc in dependsOn — choose one (a guest is a VM or a container, not both)"
     fi
 
     local dep_errors=0
@@ -197,7 +203,7 @@ main() {
     fi
 
     local provides
-    provides=$(read_module_config "${module}" | jq -r '.provides // [] | .[]' 2>/dev/null)
+    provides=$(read_module_config "${effective_module}" | jq -r '.provides // [] | .[]' 2>/dev/null)
     if [[ -z "${provides}" ]]; then
         info "  Module does not provide any services"
     else


### PR DESCRIPTION
```
## Summary
- Add validate_zone_active() to common-install-routines.sh
- Call it in install-module.sh Step 2, after JSON validation, before any action
- Early exit with actionable error: activate zone OR change zone with --zone0
- Zero side-effects on failure: no VM created, no backup registered, no Caddy route

## Test plan
- [ ] install-module.sh <module with zone0=srv_dev> → fails at Step 2 with clear error
- [ ] install-module.sh <module with zone0=srv_work> → proceeds normally
- [ ] install-module.sh <module with zone0=srv_dev> --zone0 srv_work → proceeds normally
- [ ] Module without zone0 field → proceeds normally (no zone check)

Closes #279 
🤖 Generated with help of Claude Code
```