### PR TITLE
fix(install-module): use effective_module in steps 3-5 for variant deploys

### DIFF
--- a/src/foundation/tappaas-cicd/scripts/install-module.sh
+++ b/src/foundation/tappaas-cicd/scripts/install-module.sh
@@ -158,13 +158,13 @@ main() {
     info "${BOLD}Step 3: Validate dependencies${CL}"
 
     local depends_on
-    depends_on=$(read_module_config "${module}" | jq -r '.dependsOn // [] | .[]' 2>/dev/null)
+    depends_on=$(read_module_config "${effective_module}" | jq -r '.dependsOn // [] | .[]' 2>/dev/null)
 
     # A module is either VM-backed or container-backed, never both (issue #203).
-    if read_module_config "${module}" | jq -e '(.dependsOn // []) as $d
+    if read_module_config "${effective_module}" | jq -e '(.dependsOn // []) as $d
               | (($d | index("cluster:vm")) != null)
                 and (($d | index("cluster:lxc")) != null)' >/dev/null 2>&1; then
-        die "Module '${module}' declares both cluster:vm and cluster:lxc in dependsOn — choose one (a guest is a VM or a container, not both)"
+        die "Module '${effective_module}' declares both cluster:vm and cluster:lxc in dependsOn — choose one (a guest is a VM or a container, not both)"
     fi
 
     local dep_errors=0
@@ -197,7 +197,7 @@ main() {
     fi
 
     local provides
-    provides=$(read_module_config "${module}" | jq -r '.provides // [] | .[]' 2>/dev/null)
+    provides=$(read_module_config "${effective_module}" | jq -r '.provides // [] | .[]' 2>/dev/null)
     if [[ -z "${provides}" ]]; then
         info "  Module does not provide any services"
     else


### PR DESCRIPTION
## Summary

  Steps 3-5 used `${module}` (source name) instead of `${effective_module}`
  (variant name set in step 2). For `--variant demo`, this caused a fatal
  error at step 3: config not found at `nextcloud.json` because the variant
  config was written to `nextcloud-demo.json`.

  Changed lines 161, 164, 200: `${module}` → `${effective_module}`.

  ## Test plan

  - [ ] `install-module.sh nextcloud --variant demo` passes step 3 without error
  - [ ] Non-variant deploys unaffected

  Closes #290