### PR TITLE
feat(module-fields): add appVersion field for upstream application version  

### DIFF
--- a/src/foundation/module-fields.json
+++ b/src/foundation/module-fields.json
@@ -82,6 +82,16 @@
       "example": "0.5.3",
       "note": "Major < 1 indicates module is not production-ready"
     },
+    "appVersion": {
+      "description": "Upstream application version deployed by this module. Optional but recommended. Distinct from 'version' (module semver). Treated as an informational string — no format enforced.",
+      "type": "string",
+      "requiredBy": [],
+      "usedBy": [
+        "general"
+      ],
+      "example": "33.0.3",
+      "note": "Use the upstream project's own version string: semver, date-based, or tag (e.g. '33.0.3', '1.85.0', 'nightly')"
+    },
     "releaseDate": {
       "description": "Date when this version of the module was released",
       "type": "string",


### PR DESCRIPTION
 ## Summary

  Adds `appVersion` as an optional string field to `module-fields.json`.
  
  Records the upstream application version (e.g. `33.0.3` for Nextcloud,
  `1.85.0` for LiteLLM) independently of the module's own semver (`version`).
  No format enforced — upstream projects use semver, date-based, and tag-based schemes.

  Several modules already use this field (openwebui, litellm, forgejo) and
  generated `Warning: Unknown field: appVersion` on every `install-module.sh` run.

  ## Test plan
  
  - [ ] `install-module.sh openwebui` shows no `appVersion` warning
  - [ ] `install-module.sh litellm` shows no `appVersion` warning

  Closes #295