### PR TITLE
fix(acme): ensure acme.sh dnsapi hooks exist before sign

### DIFF
--- a/src/foundation/tappaas-cicd/scripts/acme-setup.sh
+++ b/src/foundation/tappaas-cicd/scripts/acme-setup.sh
@@ -154,6 +154,28 @@ if [[ ${#CRED_FIELDS[@]} -eq 0 ]]; then
     fi
 fi
 
+# ── Preflight: ensure acme.sh DNS hooks exist on the firewall (#327) ────────
+# os-acme-client's setup.sh symlinks home/{deploy,dnsapi,notify} into the
+# acme.sh examples dir on the firewall. These can disappear on a /var/etc
+# regeneration, making every DNS-01 provider hook unfindable ("Cannot find DNS
+# API hook for: dns_<provider>"), so the sign fails with a cryptic statusCode
+# 400. Re-run setup.sh idempotently and verify the provider hook resolves
+# before signing, failing fast with a clear message instead of the opaque 400.
+case "$PROVIDER" in
+    dns_*) DNS_HOOK="${PROVIDER}.sh" ;;
+    *)     DNS_HOOK="dns_${PROVIDER}.sh" ;;
+esac
+echo
+info "${BOLD}Ensuring acme.sh DNS hooks on ${FIREWALL}${CL}"
+ssh -o ConnectTimeout=5 root@"${FIREWALL}" \
+    'sh /usr/local/opnsense/scripts/OPNsense/AcmeClient/setup.sh' 2>/dev/null \
+    || warn "  could not run os-acme-client setup.sh on ${FIREWALL} (continuing to verify)"
+if ! ssh -o ConnectTimeout=5 root@"${FIREWALL}" \
+        "test -e /var/etc/acme-client/home/dnsapi/${DNS_HOOK}"; then
+    die "acme.sh DNS hook ${DNS_HOOK} missing on ${FIREWALL} after setup.sh (see #327)"
+fi
+info "  ${GN}✓${CL} dnsapi hook ${DNS_HOOK} present"
+
 # ── Provision + sign via acme-manager ──────────────────────────────────────
 
 STAGING_ARG=()


### PR DESCRIPTION
## Summary

- **Problem:** os-acme-client's `setup.sh` symlinks `home/{deploy,dnsapi,notify}` into the acme.sh examples dir on the firewall. These can vanish on a `/var/etc` regeneration (observed without a reboot), making every DNS-01 provider hook unfindable (`Cannot find DNS API hook for: dns_<provider>`). The sign then fails with a cryptic OPNsense `statusCode 400` and no challenge TXT — silent until the next new variant/domain is issued.
- **Fix:** `acme-setup.sh` now runs `setup.sh` idempotently on the firewall and verifies the provider hook (`dns_<provider>.sh`) resolves under `/var/etc/acme-client/home/dnsapi` before signing, failing fast with a clear message instead of the opaque 400.
- **Scope:** single file, `src/foundation/tappaas-cicd/scripts/acme-setup.sh` (+22 lines). Uses the existing `ssh root@firewall` idiom and the sourced `info/warn/die` helpers; `set -e` safe.

## Test plan

- [x] `bash -n acme-setup.sh` passes.
- [ ] Repro the regression: `rm -rf /var/etc/acme-client/home/dnsapi` on the firewall, then `acme-setup.sh --variant tenant1 --provider desec` recreates the hooks via `setup.sh` and issues the cert (previously failed with `statusCode 400`).
- [ ] Hook genuinely missing (e.g. unknown provider): the run aborts before signing with `acme.sh DNS hook dns_<provider>.sh missing ... (see #327)` instead of the cryptic 400.

Closes #327

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>