### PR TITLE
fix(acme): use a separate ACME account for --staging

### DIFF
--- a/src/foundation/tappaas-cicd/scripts/acme-setup.sh
+++ b/src/foundation/tappaas-cicd/scripts/acme-setup.sh
@@ -157,7 +157,16 @@ fi
 # ── Provision + sign via acme-manager ──────────────────────────────────────
 
 STAGING_ARG=()
-[[ $STAGING -eq 1 ]] && STAGING_ARG=(--staging)
+ACCOUNT_ARG=()
+if [[ $STAGING -eq 1 ]]; then
+    STAGING_ARG=(--staging)
+    # Use a SEPARATE ACME account for staging (#329). os-acme-client keys the
+    # account by name; reusing the production account name for staging flips its
+    # CA to letsencrypt_test, so the production-registered account becomes
+    # unknown on the staging endpoint and breaks subsequent production
+    # issuance and renewals.
+    ACCOUNT_ARG=(--account-name letsencrypt-staging)
+fi
 
 PROV_ARGS=()
 for f in "${CRED_FIELDS[@]}"; do
@@ -172,6 +181,7 @@ trap 'rm -f "$LOG_FILE"' EXIT
 if ! acme-manager --firewall "$FIREWALL" --no-ssl-verify setup \
         --domain "$DOMAIN" --email "$EMAIL" \
         --provider "$PROVIDER" \
+        "${ACCOUNT_ARG[@]}" \
         "${PROV_ARGS[@]}" \
         "${STAGING_ARG[@]}" 2>&1 | tee "$LOG_FILE"; then
     die "acme-manager setup failed (see ${LOG_FILE})"


### PR DESCRIPTION
## Summary

- **Problem:** os-acme-client keys the ACME account by name. `acme-setup.sh` reused the production account name (`letsencrypt`) for staging, only switching its CA. That flips the production-registered account to `letsencrypt_test`, so production issuance fails (`statusCode 400`) and renewals of existing certs can break until the account CA is switched back.
- **Fix:** `--staging` now binds a separate account (`letsencrypt-staging`) via `--account-name`, so a staging dry-run never mutates the production account.
- **Scope:** single file, `src/foundation/tappaas-cicd/scripts/acme-setup.sh` (+11/-1). Only the `--staging` path changes; production behaviour is unchanged.

## Test plan

- [x] `bash -n acme-setup.sh` passes.
- [ ] `acme-setup.sh --variant tenant1 --provider desec --staging` creates/uses account `letsencrypt-staging` and leaves the production `letsencrypt` account on its production CA.
- [ ] A subsequent `acme-setup.sh --variant tenant1 --provider desec` (no `--staging`) issues against production with the untouched `letsencrypt` account.

Closes #329

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>