### PR TITLE
docs(unifi): note the official UniFi Network API (API key) vs legacy cookie API

### DIFF
--- a/docs/design/unifi-controller-integration.md
+++ b/docs/design/unifi-controller-integration.md
@@ -2,6 +2,8 @@
 
 This document investigates options for deploying a UniFi management solution as a TAPPaaS module and implementing the `unifi.sh` plugin for ADR-008 switch/AP automation.
 
+> **API note (UniFi Network Application v9+):** there is now an **official Network API** — REST, authenticated with an **API key** via the `X-API-KEY` header (Settings → Control Plane → Integrations → Create API Key), base path `https://<host>/proxy/network/integration/v1/...`. Prefer it for inventory/reads and supported device actions. The cookie/CSRF session API documented below (`/api/login` + `/api/s/{site}/...`) is the **legacy, community-reverse-engineered** interface — still functional, and still required for endpoints the official API does not yet cover (e.g. some `port_overrides` writes), but not officially supported. The `unifi.sh` plugin should authenticate via the API key and fall back to the legacy endpoints only where needed.
+
 ## Table of Contents
 
 1. [Background](#1-background)


### PR DESCRIPTION
## What
Adds a prominent API note to `docs/design/unifi-controller-integration.md`.

UniFi Network Application v9+ ships an **official Network API** — REST, authenticated by an **API key** (`X-API-KEY` header), base path `/proxy/network/integration/v1/...`. The design doc previously documented only the cookie/CSRF session API (`/api/login` + `/api/s/{site}/...`).

## Why
The `unifi.sh` plugin (ADR-008) should prefer the official, supported API for inventory/reads and supported device actions, and treat the cookie/CSRF interface as the **legacy/unofficial fallback** — still needed for endpoints the official API doesn't yet cover (e.g. some `port_overrides` writes).

## Change
- Doc-only: one callout after the intro. No code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)