### PR TITLE
docs(adr): decompose ADR-007 taxonomy into composable sub-ADRs + ADR-009 composition

### DIFF
--- a/docs/ADR/ADR-007 - TAPPaaS Taxonomy.md
+++ b/docs/ADR/ADR-007 - TAPPaaS Taxonomy.md
@@ -1,1031 +1,146 @@
-# ADR-001 — TAPPAAS Taxonomy & Meta-Model
+# ADR-007 — TAPPaaS Taxonomy (Overview)
 
 | | |
 |---|---|
 | **Status** | Proposed |
-| **Version** | 1.1 |
-| **Date** | 2026-06-09 |
-| **Supersedes** | Old terminology: *Variants*, *Modules*, *Tenants* |
-| **Related** | configuration.json, zones.json, module-fields.json, Authentik tenants; **composition meta-model:** issue #171 + [Capabilities](<../Architecture/Capabilities.md>) — see [Meta-model relationship](#meta-model-relationship--classification-vs-composition) |
+| **Version** | 2.0 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Supersedes** | ADR-007 v1.1 (monolithic) — decomposed into this overview + 007a–007e + ADR-009 |
+| **Related** | #320 (taxonomy); **details:** [007a People](<ADR-007a - People.md>) · [007b Apps](<ADR-007b - Apps.md>) · [007c Environments](<ADR-007c - Environments.md>) · [007d Site](<ADR-007d - Site.md>) · [007e Health](<ADR-007e - Health.md>); **composition:** [ADR-009](<ADR-009 - Composition Meta-Model.md>) + #171; **evidence + glossary:** [Architecture/taxonomy.md](<../Architecture/taxonomy.md>) |
 
 ---
 
 ## TL;DR
 
-TAPPAAS uses **one Site**, with a **3-bucket top-level taxonomy + 1 cross-cutting lens**:
+TAPPaaS uses **one Site**, with a **3-bucket top-level taxonomy + 1 cross-cutting lens**:
 
 > **👥 People · 📦 Apps · 🏠 Environments · 🩺 Health (lens)**
 
-- **People** is a 3-level hierarchy: **Organization → Group → User**
-- **Apps** have two orthogonal attributes:
-  - **`tier`** — `foundation` (cannot uninstall) or `app` (user-installable)
-  - **`source`** — `official` (TAPPAAS-maintained) or `community` (peer-reviewed) or `private` (your own catalog) or `local` (dev work)
-- **Environments** carry an **`ownerOrg`** tag
-- **Health** is an overlay, not a bucket
+This ADR is the **overview** of the model; the detail of each part lives in its own sub-ADR. How a
+deployable unit is *built* (composition) is **ADR-009**. This ADR answers *which bucket* a thing is in
+— never *how it is built*.
 
-This model is MECE, DRY, and matches industry-standard naming used by Apple, GCP, GitHub, Authentik, Backstage, Debian, and HACS. Evidence in [Appendix A](#appendix-a--industry-evidence-data-points).
+This model is MECE, DRY, and matches industry-standard naming (Apple, GCP, GitHub, Authentik,
+Backstage, Debian, HACS). Evidence: [Architecture/taxonomy.md](<../Architecture/taxonomy.md>).
 
 ---
 
-## related ADRs
+## Why this is decomposed (v1.1 → v2.0)
 
-ADR-004 (/home/tappaas/TAPPaaS/docs/ADR/ADR-004-module-catalog-config-cascade.md)
-ADR-005 (/home/tappaas/TAPPaaS/docs/ADR/ADR-005-variant-domain-architecture.md)
-ADR-006 (/home/tappaas/TAPPaaS/docs/ADR/ADR-006-identity-users-and-roles.md)
-
-## Meta-model relationship — classification vs composition
-
-This ADR is the **classification taxonomy**: it answers *which bucket* a thing is in
-(Site · People · Apps · Environments · Health) plus `tier` and `source`. It does **not** define how
-things are built.
-
-The **composition meta-model** — how a deployable unit is structured — is defined separately and is
-currently **not yet settled**: the proposed model in **issue #171**
-(`Node ▷ Module ▷ Component ▷ Function ▷ Service`) **diverges from** the current
-[Capabilities](<../Architecture/Capabilities.md>) / ArchiMate appendix on `Node` (physical machine
-vs VM), on `Capability` vs `Service`, and on `Stack` (present vs absent). Reconciliation is tracked
-on **issue #171**. This ADR's classification applies regardless of which composition model is ratified.
-
-**How they couple:** every **Module** (composition) is *classified* by exactly one ADR-007 bucket
-(+ `tier` + `source`). One model **composes**, the other **classifies** — apply both, never one as a
-substitute for the other. Example: `firewall` is a *Module* (composition) classified as
-*Environments* (this ADR); its sub-units are *Components*, not buckets.
+v1.1 was a single 1000-line document mixing the decision, every bucket's schema, the migration, and
+the appendices. v2.0 keeps **one ADR per aspect** so each is readable and changeable on its own. The
+*model is unchanged* from v1.1 — only the structure is. This also keeps classification cleanly
+separate from composition (#171), which @larsrossen asked to keep small and discussion-oriented.
 
 ---
 
-## Reading guide (progressive disclosure)
+## The model — top view
 
-| If you want... | Read |
-|---|---|
-| The decision in one paragraph | [TL;DR](#tldr) |
-| The visual model | [Decision → The Model](#the-model--top-view) |
-| Schemas to copy-paste | [Artifacts — Schemas](#the-artifacts--schemas) |
-| Decide which bucket your file goes in | [Mapping Rules → Decision Tree](#decision-tree) |
-| Old → new term conversion | [Mapping Rules → Migration Table](#old-term--new-term-migration-table) |
-| A full worked example | [Concrete Application](#concrete-application--example-soho-setup) |
-| Step-by-step migration | [Migration Path](#migration-path--from-current-config-to-new-model) |
-| The data behind each decision | [Appendix A](#appendix-a--industry-evidence-data-points) |
-| Ready-to-commit JSON files | [Appendix B](#appendix-b--sample-files-for-the-example-soho) |
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🏢 SITE  (the physical + admin perimeter — one TAPPaaS)      │
+│   ┌───────────────────────────────────────────────────────┐ │
+│   │ 👥 PEOPLE          📦 APPS          🏠 ENVIRONMENTS    │ │
+│   │ Org→Group→User     tier × source    where apps run     │ │
+│   └───────────────────────────────────────────────────────┘ │
+│   🩺 HEALTH  (lens — observability overlay on all the above) │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **Site** is the *container*, not a bucket — one TAPPaaS = one Site. → [007d](<ADR-007d - Site.md>)
+- **People · Apps · Environments** are the **3 buckets** — every artifact is exactly one of them.
+- **Health** is a **lens**, not a bucket — a cross-cutting status overlay. → [007e](<ADR-007e - Health.md>)
+
+### Why 3 buckets + 1 lens
+
+- **MECE** — every TAPPaaS artifact is exactly one of: a Person, an App, or a Place where Apps run. Zero overlap.
+- **DRY** — each concept lives in one bucket only; references by name, not duplication.
+- **Apple-test** — a non-technical user understands the top nav in 30 seconds.
+- **Ubiquiti-test** — scales from 1 site to many without changing the model.
+- **Industry-aligned** — matches K8s, Coolify, Vercel, GCP, Apple BM, UniFi (evidence: [taxonomy.md](<../Architecture/taxonomy.md>)).
+
+---
+
+## Decision tree (high level — full detail in each sub-ADR)
+
+```
+A human? ............................ User             → 007a People
+A legal/family/customer entity? ..... Organization     → 007a People
+A collection of users (RBAC)? ....... Group            → 007a People
+Something that runs? ................ App (tier+source) → 007b Apps
+A zone / domain / update window? .... Environment      → 007c Environments
+Hardware / ISP / IdP, site-wide? .... Site             → 007d Site
+A status / metric / alarm? .......... Health (lens)    → 007e Health
+```
+
+## The sub-ADRs (1 aspect each)
+
+| ADR | Aspect | Owns |
+|-----|--------|------|
+| [007a](<ADR-007a - People.md>) | 👥 People | Organization → Group → User; types; RBAC primitive |
+| [007b](<ADR-007b - Apps.md>) | 📦 Apps | the `tier` × `source` orthogonal attributes |
+| [007c](<ADR-007c - Environments.md>) | 🏠 Environments | zones, domains, `ownerOrg`, multi-tenant |
+| [007d](<ADR-007d - Site.md>) | 🏢 Site | the perimeter; `site.json`; config split |
+| [007e](<ADR-007e - Health.md>) | 🩺 Health | the cross-cutting lens |
+
+A full worked example (SOHO setup), all sample JSON files, the industry-evidence data points, and the
+glossary live in **[Architecture/taxonomy.md](<../Architecture/taxonomy.md>)** (living reference).
+
+---
+
+## Relationship to composition (delegated to ADR-009)
+
+This taxonomy **classifies**; it does not define how a unit is **built**. The composition meta-model
+(`Stack ▷ Module ▷ Component ▷ Function ▷ Service`) is **[ADR-009](<ADR-009 - Composition Meta-Model.md>)**
+(tracking issue #171). The two are orthogonal: every **Module** (composition) is *classified* by
+exactly one bucket here (+ `tier` + `source`). Apply both; never one as a substitute. *Example:*
+`firewall` is a **Module** (ADR-009) classified as **Environments** (this ADR); its sub-units are
+**Components**, not buckets.
 
 ---
 
 ## Context
 
-TAPPAAS currently uses 4 internal terms — *Variants*, *Zones*, *Modules*, *configuration.json* — that overlap, conflict, and lack a unifying mental model. New users cannot answer:
-
-- "Who can access what?"
-- "What runs where?"
-- "How do I host my family AND my business AND my clients on one TAPPAAS?"
-- "Is the firewall an App or something else?"
-- "How do I publish a community-built app?"
-
-A clean taxonomy is required before adding more features. It must be:
-
-1. **Robust** — survives future use cases without breaking
-2. **Future-proof** — handles 1-tenant home setups *and* multi-org consultancies
-3. **Scalable** — works from 1 user to 50 organizations
-4. **Enterprise-grade** — supports RBAC, audit, compliance, multi-domain
-5. **Widely adopted naming** — uses terms users already know from other platforms
-6. **B1 English** — understandable for non-technical personas (Home, NGO, SMB)
-7. **Apple/Ubiquiti-style UX** — opinionated, simple, "it just works"
-
----
-
-## Decision
-
-Adopt the model below as the canonical TAPPAAS meta-model. All schemas, docs, and UI labels follow it.
-
-### The Model — Top View
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│ 🏢 SITE  (the physical + admin perimeter — one TAPPAAS)     │
-│                                                              │
-│   ┌───────────────────────────────────────────────────────┐ │
-│   │ 👥 PEOPLE          📦 APPS          🏠 ENVIRONMENTS   │ │
-│   │ ───────────        ──────────       ──────────────    │ │
-│   │ Organizations      tier: app        (where apps run)  │ │
-│   │  └ Groups          tier: foundation                   │ │
-│   │     └ Users        + source: official|community|...   │ │
-│   └───────────────────────────────────────────────────────┘ │
-│                                                              │
-│   🩺 HEALTH  (lens — observability overlay on all the above)│
-└─────────────────────────────────────────────────────────────┘
-```
-
-### Why 3 Buckets + 1 Lens?
-
-- **MECE** — Every TAPPAAS artifact is exactly one of: Person, App, or Place where Apps run. Zero overlap.
-- **DRY** — Each concept lives in one bucket only.
-- **Apple-test** — A non-technical user understands the top nav in 30 seconds.
-- **Ubiquiti-test** — Scales from 1 site to many without changing the model.
-- **Industry-aligned** — Matches K8s, Coolify, Vercel, GCP, Apple BM, UniFi (see [App. A.1](#a1--top-level-concept-frequency-across-18-platforms)).
-
----
-
-## The Artifacts — Schemas
-
-> Examples below use generic placeholders. Replace with your own values:
-> - `<owner>` — the TAPPAAS site administrator (e.g. the founder) with email `<owner>@myhomedomain.nl`
-> - `person2`, `person3`, `person4` — other household members (partner, kids)
-> - `mybusiness-bv` — a company Organization
-> - `myhomedomain.nl` — your private root domain
-
-### 🏢 Site
-
-**Definition:** The physical + admin perimeter. One TAPPAAS = one Site. Holds everything shared across all environments inside it: hardware, WAN, DNS, IdP, backup target, admin team.
-
-**When to add a second Site:** Different ISP, different physical hardware, different legal admin team, or a DR location.
-
-**Schema** (`/home/tappaas/config/site.json`):
-
-```json
-{
-  "name": "mysite-soho",
-  "displayName": "My SOHO",
-  "owner": "<owner>",
-  "location": {
-    "country": "NL",
-    "timezone": "Europe/Amsterdam",
-    "locale": "nl_NL"
-  },
-  "network": {
-    "isp": "<your-isp>",
-    "publicIp": "auto",
-    "rootDomain": "myhomedomain.nl"
-  },
-  "dns": {
-    "provider": "<your-dns-provider>",
-    "credentialsRef": "secrets/dns-provider"
-  },
-  "hardware": {
-    "nodes": ["tappaas1", "tappaas2"],
-    "storagePools": ["tanka1", "tanka2", "tankb2"],
-    "cluster": "tappaas"
-  },
-  "identityProvider": {
-    "type": "authentik",
-    "url": "https://id.myhomedomain.nl"
-  },
-  "backup": {
-    "target": "backup.myhomedomain.nl",
-    "offsite": "tappaas-backup-buddy"
-  },
-  "updateChannel": "stable"
-}
-```
-
----
-
-### 👥 People — 3-Level Hierarchy
-
-**Hierarchy:** `Organization → Group → User`. A User can belong to many Groups across many Organizations.
-
-#### Organization
-
-**Definition:** The legal + identity entity. Maps 1:1 to an Authentik tenant. Owns Environments and Apps.
-
-**Types:** `family` · `company` · `foundation` · `customer`
-
-**Schema** (`/home/tappaas/config/people/organizations/{name}.json`):
-
-```json
-{
-  "name": "mybusiness-bv",
-  "type": "company",
-  "displayName": "MyBusiness BV",
-  "owner": "<owner>",
-  "legalEntity": "MyBusiness BV",
-  "jurisdiction": "NL",
-  "kvk": "12345678",
-  "primaryDomain": "mybusiness.nl",
-  "aliasDomains": ["mybusiness.com"],
-  "aliasMode": "redirect",
-  "authentikTenant": "id.mybusiness.nl",
-  "billing": {
-    "invoicedBy": "self"
-  },
-  "dataResidency": "eu-only",
-  "parentOrg": null
-}
-```
-
-For a **customer**, add:
-
-```json
-{
-  "name": "client-acme",
-  "type": "customer",
-  "parentOrg": "mybusiness-bv",
-  "billing": {
-    "invoicedBy": "mybusiness-bv",
-    "contractRef": "DPA-YYYY-NNN"
-  },
-  "dpaSigned": "YYYY-MM-DD"
-}
-```
-
-#### Group
-
-**Definition:** A collection of Users within one Organization. Maps 1:1 to an Authentik group. The primitive for RBAC.
-
-**Types:** `team` · `department` · `family-members` · `access-set` · `ad-hoc`
-
-The `type` field drives UI labels (e.g. `type: family-members` shows "Members" in UI; `type: team` shows "Team"; default shows "Group").
-
-**Schema** (`/home/tappaas/config/people/groups/{org}__{name}.json`):
-
-```json
-{
-  "name": "mybusiness-bv__staff",
-  "type": "team",
-  "displayName": "MyBusiness Staff",
-  "ownerOrg": "mybusiness-bv",
-  "members": ["<owner>", "person2"],
-  "authentikGroup": "mybusiness-bv-staff",
-  "roles": ["editor"]
-}
-```
-
-#### User
-
-**Definition:** An individual human. Belongs to one or more Groups (across one or more Organizations).
-
-**Schema** (`/home/tappaas/config/people/users/{name}.json`):
-
-```json
-{
-  "name": "<owner>",
-  "displayName": "<Site Administrator>",
-  "primaryEmail": "<owner>@myhomedomain.nl",
-  "memberOf": [
-    "myhome__family",
-    "mybusiness-bv__staff",
-    "tappaas-org__maintainers"
-  ],
-  "authentikUser": "<owner>"
-}
-```
-
-**Contextual UI labels** for the same User:
-
-| Group context | UI label shown |
-|---|---|
-| `myhome__family` (`type: family-members`) | "Family Member" |
-| `mybusiness-bv__staff` (`type: team`) | "Staff" |
-| `tappaas-org__maintainers` (`type: team`) | "Maintainer" |
-| (global admin view) | "User" |
-
----
-
-### 📦 Apps
-
-**Definition:** The things that run. A workload (VM, container, service) with lifecycle: install, update, test, backup, delete. Owned by a Group. Lives in one Environment.
-
-Apps have **two orthogonal attributes**:
-
-| Attribute | Values | Answers |
-|---|---|---|
-| **`tier`** | `foundation` · `app` | *Can it be uninstalled?* (lifecycle role) |
-| **`source`** | `official` · `community` · `private` · `local` | *Where does the catalog entry come from?* (origin & trust) |
-
-#### Why tier and source are separate
-
-A community app is still an *App* (same install/update/uninstall lifecycle) — it just comes from a different repo with different support guarantees. Mixing the two into one enum would break MECE. Industry confirms this (Debian, Home Assistant HACS, Nextcloud, Synology, Umbrel, YunoHost — see [App. A.7](#a7--source-vs-tier-curated-vs-community-patterns)).
-
-#### Tier values
-
-| Tier | Meaning | Example |
-|---|---|---|
-| `foundation` | Comes with platform, cannot uninstall, locks the platform if removed | `firewall`, `cluster`, `identity`, `caddy`, `backup`, `tappaas-cicd` |
-| `app` | User-installable, freely removable | `openwebui`, `nextcloud`, `vaultwarden` |
-
-#### Source values
-
-| Source | Meaning | UI badge |
-|---|---|---|
-| `official` | TAPPAAS-maintained, signed, supported by the foundation | 🟢 Verified |
-| `community` | TAPPAAS-community repo, peer-reviewed but not officially supported | 🟡 Community |
-| `private` | Hosted in a private/customer repo (e.g. a consultancy's internal apps) | 🔵 Private |
-| `local` | Developed locally, not in any catalog yet | ⚪ Local |
-
-#### Tier × Source — Valid Combinations
-
-| | source: official | source: community | source: private | source: local |
-|---|---|---|---|---|
-| **tier: foundation** | ✅ Normal case | 🟡 Rare (community fork) | ✅ Custom platform modules | ✅ Dev work |
-| **tier: app** | ✅ Normal case | ✅ Most community apps | ✅ Customer-specific apps | ✅ Dev work |
-
-Every App is exactly one cell — naturally MECE.
-
-#### Schema
-
-Folder name kept as `modules/` for filesystem backward compatibility (`/home/tappaas/config/modules/{name}.json`):
-
-```json
-{
-  "module": "openwebui",
-  "displayName": "OpenWebUI",
-  "tier": "app",
-  "source": "official",
-  "sourceMetadata": {
-    "repo": "https://github.com/tappaas-org/openwebui-module",
-    "maintainer": "tappaas-org",
-    "supportLevel": "supported",
-    "verifiedBy": "tappaas-org"
-  },
-  "version": "0.4.1",
-  "ownerGroup": "mybusiness-bv__staff",
-  "environment": "mybusiness",
-
-  "vmname": "openwebui",
-  "vmid": 311,
-  "node": "tappaas2",
-  "cores": 4,
-  "memory": "4096",
-  "diskSize": "50G",
-  "storage": "tanka1",
-  "imageType": "clone",
-  "image": "8080",
-  "bridge0": "lan",
-  "zone0": "srv-mybusiness",
-  "proxyDomain": "openwebui.mybusiness.nl",
-  "proxyPort": 8080,
-
-  "dependsOn": ["cluster:vm", "litellm:models", "identity:sso"],
-  "provides": [],
-
-  "backup": {
-    "policy": "daily-30d",
-    "items": ["postgres", "redis", "container-data", "secrets"]
-  }
-}
-```
-
-**Foundation example:**
-
-```json
-{
-  "module": "firewall",
-  "displayName": "OPNsense Firewall",
-  "tier": "foundation",
-  "source": "official",
-  "sourceMetadata": {
-    "repo": "https://github.com/tappaas-org/firewall-module",
-    "maintainer": "tappaas-org",
-    "supportLevel": "supported"
-  },
-  "version": "24.7",
-  "ownerGroup": "myhome__admins",
-  "environment": "site-wide",
-  "dependsOn": [],
-  "provides": ["proxy", "vpn", "dhcp", "dns"]
-}
-```
-
-**Community example:**
-
-```json
-{
-  "module": "some-cool-app",
-  "displayName": "Some Cool App",
-  "tier": "app",
-  "source": "community",
-  "sourceMetadata": {
-    "repo": "https://github.com/tappaas-community/some-cool-app",
-    "maintainer": "@community-contributor",
-    "supportLevel": "best-effort",
-    "verifiedBy": null
-  },
-  "version": "1.0.0",
-  "ownerGroup": "myhome__family",
-  "environment": "myhome",
-  "dependsOn": ["cluster:vm"]
-}
-```
-
----
-
-### 🏠 Environments
-
-**Definition:** Where apps run. Carries network zones, domain, update window, security posture. Owned by exactly one Organization.
-
-**When to add a second Environment per Org:** Different update timing, different domain, different security posture, multi-tenant on same hardware, or dev/staging/prod separation.
-
-**Schema** (`/home/tappaas/config/environments/{name}.json`):
-
-```json
-{
-  "name": "mybusiness",
-  "displayName": "MyBusiness Production",
-  "ownerOrg": "mybusiness-bv",
-
-  "domains": {
-    "primary": "mybusiness.nl",
-    "aliases": ["mybusiness.com"],
-    "aliasMode": "redirect"
-  },
-  "customerSubdomainPattern": "{cust}.mybusiness.nl",
-
-  "network": {
-    "zone": "srv-mybusiness",
-    "vlan": 220,
-    "firewallPosture": "strict"
-  },
-
-  "authentikTenant": "id.mybusiness.nl",
-
-  "updateWindow": "saturday-02:00-cet",
-  "updateChannel": "stable",
-
-  "backup": {
-    "retention": "7y",
-    "residency": "eu-only"
-  },
-
-  "legal": {
-    "processor": "MyBusiness BV"
-  }
-}
-```
-
----
-
-### 🩺 Health — The Lens
-
-**Definition:** Not a bucket. A cross-cutting *overlay* that shows status on People, Apps, and Environments.
-
-**Examples:**
-
-- 🟢 Badge next to an App = service responding, recent backup OK
-- 🟡 Badge next to an Environment = one node degraded, others fine
-- 🔴 Badge next to a User = MFA expired
-- Site-level health page = system-wide overview (the only dedicated Health UI page)
-
-**Why a lens, not a bucket:** Folding observability into each artifact's status badge gives the Apple "it just works" feel for non-technical users, while preserving a cross-cutting view at the Site-level for ops users.
-
----
-
-## Mapping Rules — How to Classify Any TAPPAAS Thing
-
-### Decision Tree
-
-```
-What am I looking at?
-
-├─ A human?
-│   └─ User
-│
-├─ A legal entity, family, or customer?
-│   └─ Organization (type = family|company|foundation|customer)
-│
-├─ A collection of Users for access control?
-│   └─ Group (type = team|department|family-members|access-set|ad-hoc)
-│
-├─ Something that runs (VM, container, service)?
-│   ├─ Q1: Comes with the platform, cannot uninstall?
-│   │     YES → tier: foundation        NO → tier: app
-│   └─ Q2: Where does its catalog entry come from?
-│         TAPPAAS official repo  → source: official
-│         TAPPAAS community repo → source: community
-│         A private/customer repo → source: private
-│         Local dev (not in any catalog) → source: local
-│
-├─ A network zone, domain, update window, firewall scope?
-│   └─ Environment
-│
-├─ Hardware, ISP, root domain, IdP — shared across everything?
-│   └─ Site
-│
-└─ A status indicator, log, metric, alarm?
-    └─ Health (lens — surfaces on the artifact it relates to)
-```
-
-### Old Term → New Term (Migration Table)
-
-| Old TAPPAAS term | New term | Schema field | Notes |
-|---|---|---|---|
-| Variant | Environment | `environments/{name}.json` | One file per env |
-| Module | App | (keep `modules/` folder name for compat) | UI label changes |
-| Module dependency | App dependency | `dependsOn` | Unchanged |
-| Module that is platform infra | App with `tier: foundation` | `modules/{name}.json` + `tier` | New field |
-| Module from community repo | App with `source: community` | `modules/{name}.json` + `source` | New field |
-| Tenant | Organization (user-facing) / multi-tenant (architecture term) | `organizations/{name}.json` | Tenant kept ONLY as architecture noun |
-| Zone | (kept) | inside Environment | Zone = network-implementation of Env |
-| configuration.json (mixed) | Split into `site.json` + `environments/*.json` | — | See migration path |
-| User group | Group | `groups/{org}__{name}.json` | Universal IAM primitive |
-| Variant manager | Environment manager | — | Renamed |
-
-### How to Map an Existing TAPPAAS Script or Module
-
-For each file in `src/`, ask:
-
-1. **Is it a foundation service (`src/foundation/`)?** → Map to App with `tier: foundation`, `source: official`, derive owner from the platform admin group.
-2. **Is it a user app (`src/apps/`)?** → Map to App with `tier: app`, `source: official`, owner = installing Group, env = installer's choice.
-3. **Is it from the community repo?** → Map to App with `source: community` (tier depends on whether it can be uninstalled).
-4. **Is it a script that touches the cluster, network, or IdP globally?** → It implements Site-level behavior. Document as such.
-5. **Does it touch zones, domains, firewall pinholes?** → It implements Environment-level behavior.
-6. **Does it manage user accounts, secrets, SSO?** → It implements People-level behavior.
-
----
-
-## Concrete Application — Example SOHO Setup
-
-A founder runs a household, a consulting company, contributes to TAPPAAS, and hosts one paying client. All on one physical TAPPAAS Site.
-
-```
-🏢 Site: mysite-soho
-    │
-    ├── 👥 People
-    │     ├── Organizations
-    │     │     ├── myhome          (type: family,     domain: myhomedomain.nl)
-    │     │     ├── mybusiness-bv   (type: company,    domain: mybusiness.nl + .com alias)
-    │     │     ├── tappaas-org     (type: foundation, domain: tappaas.org)
-    │     │     └── client-acme     (type: customer,   parentOrg: mybusiness-bv)
-    │     │
-    │     ├── Groups
-    │     │     ├── myhome__family
-    │     │     ├── mybusiness-bv__staff
-    │     │     ├── tappaas-org__maintainers
-    │     │     ├── tappaas-org__contributors
-    │     │     └── client-acme__admins
-    │     │
-    │     └── Users
-    │           ├── <owner>           (site administrator — member of: myhome__family, mybusiness-bv__staff, tappaas-org__maintainers)
-    │           ├── person2 (partner) (member of: myhome__family)
-    │           ├── person3 (kid)     (member of: myhome__family)
-    │           └── person4 (kid)     (member of: myhome__family)
-    │
-    ├── 🏠 Environments
-    │     ├── myhome       (ownerOrg: myhome,         zone: srv-home,        domain: myhomedomain.nl)
-    │     ├── mybusiness   (ownerOrg: mybusiness-bv,  zone: srv-mybusiness,  domain: mybusiness.nl)
-    │     ├── tappaas      (ownerOrg: tappaas-org,    zone: srv-tappaas,     domain: tappaas.org)
-    │     ├── client-acme  (ownerOrg: client-acme,    zone: srv-client-acme, domain: acme.mybusiness.nl)
-    │     └── dev          (ownerOrg: tappaas-org,    zone: srv-dev,         used cross-Org for labs)
-    │
-    └── 📦 Apps
-          ├── Foundation tier (tier=foundation, source=official)
-          │     firewall · cluster · identity · caddy · backup · tappaas-cicd
-          │
-          ├── App tier — official  (tier=app, source=official)
-          │     openwebui, vaultwarden, nextcloud, gitea, ...
-          │
-          ├── App tier — community  (tier=app, source=community)
-          │     some-cool-app from tappaas-community repo
-          │
-          └── App tier — private  (tier=app, source=private)
-                consultancy-customer-portal in mybusiness-bv's own repo
-```
-
----
-
-## Secrets — Where They Live
-
-Secrets are distributed by **what consumes them**, with RBAC (in People) controlling access:
-
-| Secret type | Bucket | Example | File location |
-|---|---|---|---|
-| Personal credential | 👥 People | Login password, MFA, personal Bitwarden vault | Authentik + Vaultwarden |
-| Workload secret | 📦 App | DB password, OAuth client secret, API key the app uses | App-scoped secret store, referenced by `secretsRef` |
-| Infrastructure secret | 🏢 Site | TLS cert key, DNS API token, cluster join token | `site.json` references, vault-managed |
-
-**Rule of thumb:** Secret belongs to the *thing that consumes it*. People-bucket RBAC decides *who can read or change it*.
-
----
-
-## Trade-offs & Risks
+TAPPaaS previously used 4 overlapping terms — *Variants*, *Zones*, *Modules*, *configuration.json* —
+that conflict and lack a unifying mental model. A clean taxonomy must be: robust, future-proof,
+scalable (1 user → 50 orgs), enterprise-grade (RBAC/audit/compliance/multi-domain), use widely-adopted
+naming, be B1-English, and feel Apple/Ubiquiti-opinionated. This ADR family is that taxonomy.
+
+## Trade-offs & risks
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| GDPR / DPA obligations for hosting client data | Legal exposure if no DPA | Article 30 register + DPA template before onboarding `client-*` Orgs |
-| Blast radius — one bad update hits family + business + clients | Multi-tenant outage | Stagger update windows: `dev` → `myhome` → `tappaas` → `mybusiness` → `client-*` |
-| Authentik single point of failure | All Orgs lose SSO at once | HA Authentik, or accept and document |
-| Cost allocation across Orgs (NL tax) | Belastingdienst may ask | Tag resource use per `ownerOrg`, allocate hardware/power proportionally |
-| `tappaas-org` legal entity unclear | Affects `legalProcessor` field | Open question — see [Parking Lot](#open-questions--parking-lot) |
-| "Tenant" jargon leaking into UI | User confusion | Strict rule: UI says "Organization", only architecture docs say "multi-tenant" |
-| Community-source apps misrepresented as official | Trust failure, security risk | UI badges per source (🟢/🟡/🔵/⚪); install warning for `source: community` |
-| Foundation modules marked as community | Platform breakage | Lint rule: `tier: foundation` requires `source: official` (or explicit override) |
+| GDPR/DPA for hosting client data | Legal exposure | Article 30 register + DPA before onboarding `client-*` Orgs |
+| Blast radius — one bad update hits family + business + clients | Multi-tenant outage | Stagger update windows: `dev`→`myhome`→`tappaas`→`mybusiness`→`client-*` |
+| Authentik single point of failure | All Orgs lose SSO | HA Authentik, or accept + document |
+| Community-source apps shown as official | Trust/security | Source badges (🟢/🟡/🔵/⚪); install warning for `community` |
+| Foundation modules marked community | Platform breakage | Lint: `tier: foundation` ⇒ `source: official` (or override) |
+| "Tenant" jargon leaks to UI | User confusion | UI says "Organization"; "tenant" only in architecture docs |
 
----
+## Open questions / parking lot
 
-## Migration Path — From Current Config to New Model
+| # | Item | Priority |
+|---|---|---|
+| 1 | `tappaas-org` legal entity (Foundation/BV/DBA?) | HIGH |
+| 6 | DPA template + Article 30 register for the consultancy Org | HIGH |
+| 2 | Customer hosting default — subdomain vs own-domain | MEDIUM |
+| 9 | Authentik HA — accept SPOF or invest? | MEDIUM |
+| 10 | Community repo location + review process | MEDIUM |
+| 8 | UniFi controller — `tier: foundation` or `app`? | LOW |
 
-### Phase 1 — Add new without breaking old (zero downtime)
-
-1. Create `/home/tappaas/config/site.json` (copy site-wide fields from `configuration.json`).
-2. Create `/home/tappaas/config/people/` directory tree (organizations, groups, users).
-3. Add `tier`, `source`, `sourceMetadata`, and `ownerGroup` fields to `module-fields.json` schema. Default existing modules to `tier: app`, `source: official`. Mark foundation modules as `tier: foundation`.
-4. Add `ownerOrg` to environment definitions; default to the family Org for legacy.
-
-### Phase 2 — Split configuration.json into site.json + environments/
-
-5. Identify which fields in `configuration.json` are Site-level vs Environment-level (table below).
-6. Move Site-level fields to `site.json`, keep Environment-level in `environments/default.json`.
-7. Update all scripts that read `configuration.json` to read from `site.json` first, fall back to old file.
-8. Mark old `configuration.json` as deprecated, schedule removal in 2 minor releases.
-
-### Phase 3 — Rename "Variant" → "Environment" in code and docs
-
-9. Symlink `copy-update-json.sh --variant` to also accept `--environment` (same behavior).
-10. Update docs and CLI help text. Deprecate `--variant` in next major release.
-
-### Phase 4 — Surface multi-Org UX + Community catalog
-
-11. Add Organization picker to relevant CLI commands and UI.
-12. Add `ownerOrg` validation in `install-module.sh`.
-13. Define community repo location, review process, and trust signal badges in UI.
-14. Document the multi-tenant + community-source workflows.
-
-### Configuration field migration map
-
-| Current `configuration.json` field | Goes to |
-|---|---|
-| `domain`, `rootDomain` | `site.json → network.rootDomain` |
-| `nodes` | `site.json → hardware.nodes` |
-| `dns provider` | `site.json → dns` |
-| `backup target` | `site.json → backup` |
-| `timezone`, `locale` | `site.json → location` |
-| `updateSchedule` | `environments/default.json → updateWindow` |
-| `subdomain prefix` | `environments/{name}.json → domains` |
-| `active zones` | `environments/{name}.json → network.zone` |
-
----
-
-## Open Questions / Parking Lot
-
-| # | Item | Priority | Next action |
-|---|---|---|---|
-| 1 | `tappaas-org` legal entity — Foundation, BV, or DBA? | HIGH | Decide before client onboarding; affects `legalProcessor` |
-| 2 | Customer hosting default — subdomain vs own-domain | MEDIUM | Pick default offer, allow upgrade |
-| 3 | Alias modes per Org (redirect vs mirror vs split) | LOW | One-sentence intent statement per alias |
-| 4 | DNS reservations for `tappaas.org` subdomains (docs/demo/community/git/id/status) | LOW | 5-min DNS task |
-| 5 | Family sub-groups (parents/kids/guests) | LOW | YAGNI until first parental-control app |
-| 6 | DPA template + Article 30 register for the consultancy Org | HIGH | Legal blocker for client hosting |
-| 7 | TAPPAAS positioning as "MSP-lite for solopreneurs" | STRATEGIC | Validate with 3-5 target users |
-| 8 | UniFi controller — `tier: foundation` or `tier: app`? | LOW | Per-Site decision in `site.json` |
-| 9 | Authentik HA — accept SPOF or invest? | MEDIUM | Risk-based, defer until > 2 clients |
-| 10 | Community repo location and review process | MEDIUM | Decide Git org structure, review checklist, signing rules |
-| 11 | Trust signal UI design (HACS-style badges) | LOW | Post-MVP UX work |
-| 12 | Private/customer catalogs | LOW (or HIGH if MSP-lite) | Define how a consultancy hosts its own catalog |
-
----
+(Full parking lot retained from v1.1 history.)
 
 ## Consequences
 
-### Positive
-
-- One model covers Home, SMB, NGO, dev, MSP-lite, and multi-org consulting setups.
-- DRY: each concept lives in one place; references are by name, not duplication.
-- Aligns 1:1 with Authentik primitives (Tenant, Group, User).
-- `tier` + `source` separation gives Apple-iOS-style UX with a single pipeline — and supports community ecosystem from day one.
-- Industry-aligned naming reduces learning curve for new users.
-
-### Negative
-
-- Migration touches scripts across `src/foundation/`.
-- Renaming Variant → Environment requires backward-compat shims for one release cycle.
-- File-tree restructuring affects backup scripts, snapshot paths, and docs.
-- Documentation rewrite needed across `docs/Architecture/*`.
-- Community catalog needs governance setup before launch.
-
-### Neutral
-
-- Foundation/App distinction is semantic only — runtime is identical.
-- Source is metadata only — runtime is identical regardless of where the catalog entry came from.
-
----
-
-## Acceptance Criteria
-
-This ADR is accepted when:
-
-- [ ] `site.json` schema validated by `validate-configuration.sh`
-- [ ] Sample `organizations/`, `groups/`, `users/` files created
-- [ ] `tier`, `source`, `sourceMetadata`, `ownerGroup` added to `module-fields.json`
-- [ ] At least one module re-tagged with new schema and passes `install-module.sh`
-- [ ] At least one `source: community` module installed end-to-end as proof
-- [ ] Migration of `configuration.json` documented step-by-step
-- [ ] UI mockup of 3-bucket nav + Health lens + source badges reviewed
-
----
-
-# Appendix A — Industry Evidence (Data Points)
-
-All design decisions in this ADR are backed by frequency analysis across 18+ platforms. Below is the raw evidence per decision.
-
-## A.1 — Top-level concept frequency across 18 platforms
-
-Why **People · Apps · Environments** as the three buckets:
-
-| Concept | Found in | Count |
-|---|---|---|
-| Identity / People / Users (some form) | All 18 | 18/18 |
-| App / Workload / Service (some form) | All 18 | 18/18 |
-| Environment | K8s, Coolify, Vercel, Backstage (System), GCP, AWS, Azure, Heroku | 8/10 |
-| Project / Site (above Env) | Coolify, Vercel, UniFi, Backstage, AWS, Azure, GCP, Apple BM | 8/10 |
-| Resource (distinct from App) | AWS, Azure, GCP, K8s, Backstage, Coolify | 6/10 |
-| Health / Observability as separate bucket | K8s, UniFi, Backstage, AWS, Azure, GCP, Synology | 7/10 |
-
-**Conclusion:** People, Apps, Environments are universal. Health is universally tracked but variably positioned — TAPPAAS chooses *lens* over *bucket* for prosumer UX.
-
-## A.2 — "Tenant" vs "Organization" naming
-
-Why we use **Organization** in UI and **tenant** only as architecture term:
-
-| Term | Platforms using it | Count |
-|---|---|---|
-| **Organization / Org** | GCP, GitHub, Okta, Salesforce, HashiCorp Cloud, Google Workspace, Apple Business Manager, AWS Organizations, Auth0 (B2B), Microsoft (user-facing) | **10** |
-| Tenant | Azure (technical), Authentik, Auth0 (technical), Microsoft 365 (admin docs) | 4 |
-| Workspace | Slack, Notion | 2 |
-| Team | Vercel | 1 |
-| Group | GitLab | 1 |
-| Family | Apple Family Sharing | 1 (consumer) |
-| Realm | Keycloak | 1 |
-| Account | AWS (per-account), UniFi | 1-2 |
-
-**Conclusion:** Organization wins ~2.5×. Tenant is for *architecture docs only*.
-
-## A.3 — "Group" vs "Team" for the middle People layer
-
-Why we use **Group** as primitive, with `type: team` as optional display label:
-
-**Identity / IAM systems (where TAPPAAS plugs in):**
-
-| System | Term |
-|---|---|
-| LDAP, Active Directory, Authentik, Keycloak, AWS IAM, Azure AD/Entra, GCP IAM, Okta, Auth0, Linux/Unix, Kubernetes RBAC, Backstage | **Group** |
-
-**12/12 IAM systems use "Group".** Confirmed by current RBAC literature: bindings map identities or groups to roles.
-
-**Collaboration tools (a different layer):**
-
-| Tool | Term |
-|---|---|
-| GitHub, Vercel, Linear, Asana, Atlassian, Notion, HashiCorp Cloud, Slack, Microsoft Teams, Coolify | **Team** |
-
-**Universality test (covers all 7 TAPPAAS use cases):**
-
-| Use case | Group fits? | Team fits? |
-|---|---|---|
-| Family members | ✅ | ❌ (awkward) |
-| Company staff | ✅ | ✅ |
-| OSS contributors | ✅ | 🟡 |
-| Auditors (read-only) | ✅ | ❌ (not a team) |
-| On-call rotation | ✅ | ✅ |
-| Mailing list | ✅ | ❌ |
-| Ad-hoc reviewers | ✅ | ❌ |
-
-**Conclusion:** Group is the primitive (7/7 coverage); Team is a display *type* (Backstage-style).
-
-## A.4 — Top-level hierarchies of comparable platforms
-
-| Platform | Hierarchy (top → bottom) |
-|---|---|
-| **Backstage** | Domain → System → Component (+ API, Resource) + Users/Groups |
-| **Coolify** | Server → Project → Environment → Resource (+ Teams) |
-| **Vercel** | Team → Project → Environment → Deployment |
-| **K8s** | Cluster → Namespace → Workload (RBAC cross-cuts) |
-| **UniFi** | Account → Site → Devices/Clients/Networks/Profiles |
-| **Apple Business Manager** | Org → Location → Devices + Apps + Users + Profiles |
-| **AWS** | Organization → Account → VPC/Region → Resource |
-| **Azure** | Tenant → Subscription → Resource Group → Resource |
-| **GCP** | Organization → Folder → Project → Resource |
-| **Terraform / HCP** | Org → Workspace → Resource (+ Teams) |
-| **TAPPAAS (this ADR)** | Site → People/Apps/Environments (3-bucket flat under Site) + Health lens |
-
-**TAPPAAS is intentionally flatter** to match prosumer UX. Multi-Org sits inside People (not as a hierarchical layer), avoiding the AWS/Azure complexity that overwhelms small users.
-
-## A.5 — "Environment" universal adoption
-
-| Platform | Uses "Environment"? |
-|---|---|
-| Kubernetes (Namespace) | ✅ Effectively |
-| Coolify | ✅ Direct |
-| Vercel | ✅ Direct |
-| Backstage (via System) | ✅ Implicit |
-| GCP, AWS, Azure | ✅ Direct |
-| Heroku | ✅ Direct |
-| Apple Business Manager (Location/Profile) | ✅ Indirect |
-| UniFi (Site) | ✅ Indirect |
-| Synology DSM, YunoHost, Umbrel, CasaOS | ❌ (single-env by design) |
-
-**Conclusion:** "Environment" is the *de facto* term in any multi-env-capable platform.
-
-## A.6 — Industry pattern recognition for multi-Org-on-one-host setups
-
-The "one founder, multiple ventures, on one infrastructure" pattern maps to recognized industry patterns:
-
-| Industry Pattern | Examples |
-|---|---|
-| **Multi-account / Organizations** (cloud) | AWS Organizations, GCP folders, Azure subscriptions |
-| **MSP multi-tenant** | UniFi Site Manager, ConnectWise, NinjaOne, Microsoft CSP |
-| **Holding company IT** | Family office serving multiple LLCs |
-| **Indie-hacker / Solopreneur domains** | 37signals (Basecamp, Hey), Pieter Levels (Nomadlist, RemoteOK), Levels.fyi |
-| **Authentik / Keycloak Realms** | Native multi-realm identity isolation |
-
-**Conclusion:** Common pattern at enterprise scale, **gap in prosumer FOSS** — a real positioning opportunity for TAPPAAS.
-
-## A.7 — Source vs Tier (curated vs community) patterns
-
-Why we model `source` as a separate dimension from `tier`:
-
-| Platform | Lifecycle (tier-equivalent) | Source/Origin (catalog) |
-|---|---|---|
-| **Debian** | Same (`apt install`) | `main` · `universe` · `multiverse` (4 components) |
-| **Ubuntu** | Same | `main` · `restricted` · `universe` · `multiverse` |
-| **Home Assistant** | Same (integration) | Core integrations vs **HACS** (community) |
-| **Nextcloud** | Same (app) | Official · Featured · 3rd party |
-| **Synology DSM** | Same (Package Center) | Synology · Community |
-| **Umbrel** | Same | Official Store · Community Store |
-| **YunoHost** | Same | Official · Working · Inprogress · Notworking |
-| **WordPress** | Different — core can't be uninstalled | Core (tier=foundation) + Plugins (source=official/3rd) |
-| **iOS** | Different — System Apps can't be uninstalled | System (tier=foundation) + App Store (source=apple) |
-
-**Conclusion:** 7/9 platforms model curated-vs-community as **source** (separate from lifecycle). 2 platforms use `tier` only when *lifecycle genuinely differs* — exactly what TAPPAAS does with `foundation` vs `app`. The two dimensions are orthogonal and both are needed.
-
----
-
-# Appendix B — Sample Files for the Example SOHO
-
-Ready-to-commit JSON files for the example setup. Use as starting point for migration Phase 1. Replace placeholder values (`<owner>`, `mybusiness-bv`, `myhomedomain.nl`, etc.) with your own.
-
-## site.json
-
-```json
-{
-  "name": "mysite-soho",
-  "displayName": "My SOHO",
-  "owner": "<owner>",
-  "location": { "country": "NL", "timezone": "Europe/Amsterdam", "locale": "nl_NL" },
-  "network": { "rootDomain": "myhomedomain.nl" },
-  "dns": { "provider": "<your-dns-provider>", "credentialsRef": "secrets/dns-provider" },
-  "hardware": { "nodes": ["tappaas1", "tappaas2"], "storagePools": ["tanka1", "tankb2"], "cluster": "tappaas" },
-  "identityProvider": { "type": "authentik", "url": "https://id.myhomedomain.nl" },
-  "backup": { "target": "backup.myhomedomain.nl", "offsite": "tappaas-backup-buddy" },
-  "updateChannel": "stable"
-}
-```
-
-## people/organizations/
-
-```json
-// myhome.json
-{
-  "name": "myhome",
-  "type": "family",
-  "displayName": "My Home",
-  "owner": "<owner>",
-  "primaryDomain": "myhomedomain.nl",
-  "authentikTenant": "id.myhomedomain.nl",
-  "jurisdiction": "NL"
-}
-
-// mybusiness-bv.json
-{
-  "name": "mybusiness-bv",
-  "type": "company",
-  "displayName": "MyBusiness BV",
-  "owner": "<owner>",
-  "legalEntity": "MyBusiness BV",
-  "jurisdiction": "NL",
-  "kvk": "12345678",
-  "primaryDomain": "mybusiness.nl",
-  "aliasDomains": ["mybusiness.com"],
-  "aliasMode": "redirect",
-  "authentikTenant": "id.mybusiness.nl",
-  "dataResidency": "eu-only"
-}
-
-// tappaas-org.json
-{
-  "name": "tappaas-org",
-  "type": "foundation",
-  "displayName": "TAPPAAS",
-  "owner": "<owner>",
-  "legalEntity": "TBD — see Parking Lot #1",
-  "jurisdiction": "EU",
-  "primaryDomain": "tappaas.org",
-  "aliasDomains": [],
-  "authentikTenant": "id.tappaas.org",
-  "dataResidency": "eu-only"
-}
-
-// client-acme.json (template)
-{
-  "name": "client-acme",
-  "type": "customer",
-  "parentOrg": "mybusiness-bv",
-  "displayName": "ACME B.V.",
-  "legalEntity": "ACME B.V.",
-  "jurisdiction": "NL",
-  "primaryDomain": "acme.mybusiness.nl",
-  "authentikTenant": "id.acme.mybusiness.nl",
-  "billing": { "invoicedBy": "mybusiness-bv", "contractRef": "DPA-YYYY-NNN" },
-  "dataResidency": "eu-only",
-  "dpaSigned": "YYYY-MM-DD"
-}
-```
-
-## people/groups/
-
-```json
-// myhome__family.json
-{
-  "name": "myhome__family",
-  "type": "family-members",
-  "displayName": "Family",
-  "ownerOrg": "myhome",
-  "members": ["<owner>", "person2", "person3", "person4"],
-  "authentikGroup": "myhome-family"
-}
-
-// mybusiness-bv__staff.json
-{
-  "name": "mybusiness-bv__staff",
-  "type": "team",
-  "displayName": "MyBusiness Staff",
-  "ownerOrg": "mybusiness-bv",
-  "members": ["<owner>"],
-  "authentikGroup": "mybusiness-bv-staff",
-  "roles": ["admin"]
-}
-```
-
-## people/users/
-
-```json
-// <owner>.json
-{
-  "name": "<owner>",
-  "displayName": "<Site Administrator>",
-  "primaryEmail": "<owner>@myhomedomain.nl",
-  "memberOf": [
-    "myhome__family",
-    "mybusiness-bv__staff",
-    "tappaas-org__maintainers"
-  ],
-  "authentikUser": "<owner>"
-}
-```
-
-## environments/
-
-```json
-// myhome.json
-{
-  "name": "myhome",
-  "displayName": "My Home",
-  "ownerOrg": "myhome",
-  "domains": { "primary": "myhomedomain.nl", "aliases": [], "aliasMode": "redirect" },
-  "network": { "zone": "srv-home", "vlan": 210, "firewallPosture": "balanced" },
-  "authentikTenant": "id.myhomedomain.nl",
-  "updateWindow": "weekend",
-  "backup": { "retention": "long-term-personal", "residency": "eu-only" }
-}
-
-// mybusiness.json
-{
-  "name": "mybusiness",
-  "displayName": "MyBusiness Production",
-  "ownerOrg": "mybusiness-bv",
-  "domains": { "primary": "mybusiness.nl", "aliases": ["mybusiness.com"], "aliasMode": "redirect" },
-  "customerSubdomainPattern": "{cust}.mybusiness.nl",
-  "network": { "zone": "srv-mybusiness", "vlan": 220, "firewallPosture": "strict" },
-  "authentikTenant": "id.mybusiness.nl",
-  "updateWindow": "saturday-02:00-cet",
-  "backup": { "retention": "7y", "residency": "eu-only" },
-  "legal": { "processor": "MyBusiness BV" }
-}
-
-// tappaas.json
-{
-  "name": "tappaas",
-  "displayName": "TAPPAAS Community",
-  "ownerOrg": "tappaas-org",
-  "domains": { "primary": "tappaas.org", "aliases": [], "aliasMode": "redirect" },
-  "network": { "zone": "srv-tappaas", "vlan": 230, "firewallPosture": "balanced" },
-  "authentikTenant": "id.tappaas.org",
-  "updateChannel": "edge",
-  "backup": { "retention": "1y", "residency": "eu-only" }
-}
-```
-
----
-
-# Appendix C — Glossary
-
-| Term | Definition |
-|---|---|
-| **Site** | The physical + admin perimeter. One TAPPAAS = one Site. |
-| **Organization** | A legal or identity entity (family, company, foundation, customer). Owns Envs and Apps. |
-| **Group** | A collection of Users for access control. Lives in one Org. |
-| **User** | An individual human. Can be in many Groups across many Orgs. |
-| **Environment** | Where Apps run. Has zone, domain, update window. Owned by an Org. |
-| **App** | A workload (VM, container, service). Has a `tier` and a `source`. |
-| **Tier** | App classification by lifecycle: `foundation` (platform, cannot uninstall) or `app` (user-installable). |
-| **Source** | App classification by origin: `official` (TAPPAAS-maintained), `community` (peer-reviewed), `private` (your own catalog), `local` (dev work). |
-| **Health** | Cross-cutting observability lens. Not a bucket — overlays the other artifacts. |
-| **Tenant** | Architecture term for "isolated customer of a multi-tenant system". *Not* a UI term in TAPPAAS — that's Organization. |
-| **DPA** | Data Processing Agreement (GDPR). Required when one Org hosts another Org's data. |
-| **MSP** | Managed Service Provider — pattern where one infrastructure serves multiple client Orgs. |
-| **Community catalog** | The TAPPAAS-community repo of `source: community` modules. Peer-reviewed, not officially supported. |
+- **Positive** — one model covers Home/SMB/NGO/dev/MSP-lite/multi-org; DRY; aligns 1:1 with Authentik
+  primitives; `tier`+`source` give Apple-style UX with a community ecosystem from day one.
+- **Negative** — migration touches `src/foundation/` scripts; Variant→Environment needs a compat shim
+  for one release; docs rewrite across `docs/Architecture/*`.
+- **Neutral** — foundation/app and source are semantic/metadata only; runtime identical.
+
+## Acceptance (overview)
+
+Accepted when all sub-ADRs (007a–007e) are accepted and ADR-009's classification-coupling is
+consistent. Per-aspect acceptance criteria live in each sub-ADR; the reference doc holds the sample
+files used to validate them.

--- a/docs/ADR/ADR-007a - People.md
+++ b/docs/ADR/ADR-007a - People.md
@@ -1,0 +1,89 @@
+# ADR-007a — People
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Version** | 1.0 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Parent** | [ADR-007 Taxonomy (Overview)](<ADR-007 - TAPPaaS Taxonomy.md>) |
+| **Related** | #320; ADR-006 (identity — users, roles, SSO) |
+
+The **👥 People** bucket — one of ADR-007's three buckets.
+
+## Decision
+
+People is a **3-level hierarchy**: `Organization → Group → User`. A User can belong to many Groups
+across many Organizations. Maps 1:1 onto Authentik primitives (Tenant · Group · User). RBAC is built on
+**Group** (the universal IAM primitive); role/SSO provisioning is ADR-006.
+
+## The three levels
+
+| Level | Definition | `type` values | Authentik |
+|-------|------------|---------------|-----------|
+| **Organization** | legal/identity entity; owns Environments + Apps | `family` · `company` · `foundation` · `customer` | Tenant (1:1) |
+| **Group** | collection of Users within one Org; the RBAC primitive | `team` · `department` · `family-members` · `access-set` · `ad-hoc` | Group (1:1) |
+| **User** | an individual human; belongs to ≥1 Group | — | User (1:1) |
+
+`type` drives UI labels only (e.g. `family-members` → "Members", `team` → "Team", default → "Group").
+
+### Organization — schema (`config/people/organizations/{name}.json`)
+
+```json
+{
+  "name": "mybusiness-bv",
+  "type": "company",
+  "displayName": "MyBusiness BV",
+  "owner": "<owner>",
+  "legalEntity": "MyBusiness BV",
+  "jurisdiction": "NL",
+  "primaryDomain": "mybusiness.nl",
+  "aliasDomains": ["mybusiness.com"],
+  "aliasMode": "redirect",
+  "authentikTenant": "id.mybusiness.nl",
+  "dataResidency": "eu-only",
+  "parentOrg": null
+}
+```
+
+A **customer** adds `parentOrg`, `billing.invoicedBy`, `billing.contractRef`, `dpaSigned`.
+
+### Group — schema (`config/people/groups/{org}__{name}.json`)
+
+```json
+{
+  "name": "mybusiness-bv__staff",
+  "type": "team",
+  "displayName": "MyBusiness Staff",
+  "ownerOrg": "mybusiness-bv",
+  "members": ["<owner>", "person2"],
+  "authentikGroup": "mybusiness-bv-staff",
+  "roles": ["editor"]
+}
+```
+
+### User — schema (`config/people/users/{name}.json`)
+
+```json
+{
+  "name": "<owner>",
+  "displayName": "<Site Administrator>",
+  "primaryEmail": "<owner>@myhomedomain.nl",
+  "memberOf": ["myhome__family", "mybusiness-bv__staff", "tappaas-org__maintainers"],
+  "authentikUser": "<owner>"
+}
+```
+
+The same User shows contextual UI labels per Group (`family-members`→"Family Member", `team`→"Staff"/
+"Maintainer", global→"User").
+
+## Why Group (not Team) as the primitive
+
+12/12 IAM systems (LDAP, AD, Authentik, Keycloak, AWS/Azure/GCP IAM, Okta, Auth0, K8s RBAC, Backstage)
+use **Group**; Team is a collaboration-tool label. Group covers all 7 TAPPaaS use cases; Team does
+not. Evidence: [Architecture/taxonomy.md](<../Architecture/taxonomy.md>) → A.3.
+
+## Acceptance
+
+- [ ] Sample `organizations/`, `groups/`, `users/` files created and validated.
+- [ ] Consistent with ADR-006 (role profiles, SSO provisioning).

--- a/docs/ADR/ADR-007b - Apps.md
+++ b/docs/ADR/ADR-007b - Apps.md
@@ -1,0 +1,86 @@
+# ADR-007b — Apps
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Version** | 1.0 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Parent** | [ADR-007 Taxonomy (Overview)](<ADR-007 - TAPPaaS Taxonomy.md>) |
+| **Related** | #320; #297 (module-catalog stack/category); **composition:** [ADR-009](<ADR-009 - Composition Meta-Model.md>) + #171 |
+
+The **📦 Apps** bucket. An App = a thing that runs (VM, container, service) with a lifecycle: install,
+update, test, backup, delete. Owned by a Group, lives in one Environment.
+
+## Decision
+
+Apps carry **two orthogonal attributes** — never collapsed into one enum (that would break MECE):
+
+| Attribute | Values | Answers |
+|-----------|--------|---------|
+| **`tier`** | `foundation` · `app` | *Can it be uninstalled?* (lifecycle role) |
+| **`source`** | `official` · `community` · `private` · `local` | *Where does the catalog entry come from?* (origin & trust) |
+
+Every App is exactly one cell of the `tier × source` grid — naturally MECE.
+
+### `tier`
+
+| Tier | Meaning | Example |
+|------|---------|---------|
+| `foundation` | ships with platform, cannot uninstall, removing it breaks the platform | `firewall`, `cluster`, `identity`, `caddy`, `backup`, `tappaas-cicd` |
+| `app` | user-installable, freely removable | `openwebui`, `nextcloud`, `vaultwarden` |
+
+### `source`
+
+| Source | Meaning | Badge |
+|--------|---------|-------|
+| `official` | TAPPaaS-maintained, signed, supported | 🟢 Verified |
+| `community` | community repo, peer-reviewed, not officially supported | 🟡 Community |
+| `private` | private/customer repo | 🔵 Private |
+| `local` | local dev, not in any catalog | ⚪ Local |
+
+### Valid `tier × source` combinations
+
+| | official | community | private | local |
+|---|---|---|---|---|
+| **foundation** | ✅ normal | 🟡 rare (fork) | ✅ custom platform | ✅ dev |
+| **app** | ✅ normal | ✅ most community apps | ✅ customer-specific | ✅ dev |
+
+## Schema (`config/modules/{name}.json` — folder kept as `modules/` for compatibility)
+
+```json
+{
+  "module": "openwebui",
+  "displayName": "OpenWebUI",
+  "tier": "app",
+  "source": "official",
+  "sourceMetadata": { "repo": "https://github.com/tappaas-org/openwebui-module", "maintainer": "tappaas-org", "supportLevel": "supported", "verifiedBy": "tappaas-org" },
+  "version": "0.4.1",
+  "ownerGroup": "mybusiness-bv__staff",
+  "environment": "mybusiness",
+  "vmname": "openwebui", "vmid": 311, "node": "tappaas2",
+  "dependsOn": ["cluster:vm", "litellm:models", "identity:sso"],
+  "provides": []
+}
+```
+
+New classification fields: `tier`, `source`, `sourceMetadata`, `ownerGroup`. Lint rule:
+`tier: foundation` ⇒ `source: official` (or explicit override).
+
+> **`node` = the physical Proxmox host** (e.g. `tappaas2`) the App's VM is installed on — see
+> [007d Site](<ADR-007d - Site.md>) and [ADR-009](<ADR-009 - Composition Meta-Model.md>).
+
+> **Boundary with ADR-009 / #297.** This ADR owns *classification* fields (`tier`, `source`). The
+> *composition* (Module ▷ Component ▷ Function ▷ Service) is **ADR-009**. The *catalog/discovery*
+> facets (`stack`/`category`, #297) are a separate axis — ADR-009 covers the relation + the "Stack"
+> naming note.
+
+## Why tier and source are separate
+
+7/9 platforms (Debian, Ubuntu, HACS, Nextcloud, Synology, Umbrel, YunoHost) model curated-vs-community
+as **source**, separate from lifecycle **tier**. Evidence: [taxonomy.md](<../Architecture/taxonomy.md>) → A.7.
+
+## Acceptance
+
+- [ ] `tier`, `source`, `sourceMetadata`, `ownerGroup` added to `module-fields.json`.
+- [ ] One module re-tagged + passes `install-module.sh`; one `source: community` module installed e2e.

--- a/docs/ADR/ADR-007c - Environments.md
+++ b/docs/ADR/ADR-007c - Environments.md
@@ -1,0 +1,54 @@
+# ADR-007c — Environments
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Version** | 1.0 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Parent** | [ADR-007 Taxonomy (Overview)](<ADR-007 - TAPPaaS Taxonomy.md>) |
+| **Related** | #320; #318 (rename "variant"→Environment); #319 (zone deletion); #294 (zone-aligned VMID); #313 (timezone→config) |
+
+The **🏠 Environments** bucket. An Environment = **where apps run**: network zones, domain, update
+window, security posture. Owned by **exactly one Organization** (`ownerOrg`).
+
+## Decision
+
+- An Environment carries: `domains`, `network.zone` (+ `vlan`, `firewallPosture`), `authentikTenant`,
+  `updateWindow`/`updateChannel`, `backup` (retention/residency), `legal.processor`.
+- **Multi-tenant:** many Environments may share hardware; each is owned by one Org. A customer
+  subdomain pattern (`{cust}.<domain>`) supports MSP-style hosting.
+- **Add a second Environment per Org** when update timing, domain, security posture, or
+  dev/staging/prod separation differ.
+
+## Schema (`config/environments/{name}.json`)
+
+```json
+{
+  "name": "mybusiness",
+  "displayName": "MyBusiness Production",
+  "ownerOrg": "mybusiness-bv",
+  "domains": { "primary": "mybusiness.nl", "aliases": ["mybusiness.com"], "aliasMode": "redirect" },
+  "customerSubdomainPattern": "{cust}.mybusiness.nl",
+  "network": { "zone": "srv-mybusiness", "vlan": 220, "firewallPosture": "strict" },
+  "authentikTenant": "id.mybusiness.nl",
+  "updateWindow": "saturday-02:00-cet",
+  "updateChannel": "stable",
+  "backup": { "retention": "7y", "residency": "eu-only" },
+  "legal": { "processor": "MyBusiness BV" }
+}
+```
+
+`Zone` is the **network-implementation** of an Environment (kept as a term inside the Environment),
+not a separate bucket.
+
+## Migration (terminology)
+
+The old term **Variant** becomes **Environment** (#318). `copy-update-json.sh --variant` aliases to
+`--environment` for one release; `--variant` deprecated next major. Zone-deletion semantics for
+managed-vs-client zones are tracked on #319; zone-aligned VMID ranges on #294.
+
+## Acceptance
+
+- [ ] `ownerOrg` present on every Environment; defaults to the family Org for legacy.
+- [ ] `install-module.sh` validates `ownerOrg`; `--environment` accepted alongside `--variant`.

--- a/docs/ADR/ADR-007d - Site.md
+++ b/docs/ADR/ADR-007d - Site.md
@@ -1,0 +1,64 @@
+# ADR-007d — Site
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Version** | 1.0 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Parent** | [ADR-007 Taxonomy (Overview)](<ADR-007 - TAPPaaS Taxonomy.md>) |
+| **Related** | #320; #313 (timezone→site.json); ADR-004 (config cascade) |
+
+The **🏢 Site** — the **container**, not a bucket. One TAPPaaS = one Site: the physical + admin
+perimeter holding everything shared across all Environments inside it.
+
+## Decision
+
+- A Site owns: hardware (`nodes`, `storagePools`, `cluster`), WAN/ISP, `rootDomain`, DNS provider,
+  identity provider (Authentik), backup target, update channel, location (country/timezone/locale).
+- **`nodes` are the physical Proxmox hosts** (`tappaas1`, `tappaas2`) — the same `node` the module
+  schema refers to (the physical host an App's VM is installed on). The composition naming of
+  physical-host-vs-VM is reconciled in **[ADR-009](<ADR-009 - Composition Meta-Model.md>)**; the schema
+  usage here — `node` = physical host — is authoritative.
+- **Add a second Site** only for: different ISP, different physical hardware, different legal admin
+  team, or a DR location.
+
+## Schema (`config/site.json`)
+
+```json
+{
+  "name": "mysite-soho",
+  "displayName": "My SOHO",
+  "owner": "<owner>",
+  "location": { "country": "NL", "timezone": "Europe/Amsterdam", "locale": "nl_NL" },
+  "network": { "isp": "<your-isp>", "publicIp": "auto", "rootDomain": "myhomedomain.nl" },
+  "dns": { "provider": "<your-dns-provider>", "credentialsRef": "secrets/dns-provider" },
+  "hardware": { "nodes": ["tappaas1", "tappaas2"], "storagePools": ["tanka1", "tankb2"], "cluster": "tappaas" },
+  "identityProvider": { "type": "authentik", "url": "https://id.myhomedomain.nl" },
+  "backup": { "target": "backup.myhomedomain.nl", "offsite": "tappaas-backup-buddy" },
+  "updateChannel": "stable"
+}
+```
+
+## Config split (migration)
+
+The legacy mixed `configuration.json` splits into **`site.json`** (site-wide) + **`environments/*.json`**
+(per-environment), aligned with ADR-004:
+
+| `configuration.json` field | Goes to |
+|---|---|
+| `domain`, `rootDomain` | `site.json → network.rootDomain` |
+| `nodes` | `site.json → hardware.nodes` |
+| `dns provider`, `backup target` | `site.json → dns` / `backup` |
+| `timezone`, `locale` | `site.json → location` |
+| `updateSchedule` | `environments/{name}.json → updateWindow` |
+| `subdomain prefix` | `environments/{name}.json → domains` |
+| `active zones` | `environments/{name}.json → network.zone` |
+
+Scripts read `site.json` first, fall back to the old file; deprecate `configuration.json` over 2 minor
+releases.
+
+## Acceptance
+
+- [ ] `site.json` schema validated by `validate-configuration.sh`.
+- [ ] Site-level fields migrated out of `configuration.json`; fallback path works.

--- a/docs/ADR/ADR-007e - Health.md
+++ b/docs/ADR/ADR-007e - Health.md
@@ -1,0 +1,41 @@
+# ADR-007e — Health (Lens)
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Version** | 1.0 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Parent** | [ADR-007 Taxonomy (Overview)](<ADR-007 - TAPPaaS Taxonomy.md>) |
+| **Related** | #320 |
+
+The **🩺 Health** lens. **Not a bucket** — a cross-cutting *overlay* that shows status on People,
+Apps, and Environments.
+
+## Decision
+
+Health is a **lens**, not a fourth bucket. Observability is folded into each artifact's status badge,
+with a single Site-level Health page as the system-wide overview. This keeps the "it just works"
+prosumer UX (status on the thing it relates to) while preserving a cross-cutting ops view.
+
+## How it surfaces
+
+| Where | Example |
+|-------|---------|
+| next to an **App** | 🟢 service responding, recent backup OK |
+| next to an **Environment** | 🟡 one node degraded, others fine |
+| next to a **User** | 🔴 MFA expired |
+| Site-level Health page | system-wide overview (the only dedicated Health UI page) |
+
+## Why a lens, not a bucket
+
+A module that *observes everything* cannot be MECE-assigned to a single bucket. Modeling Health as a
+classification bucket would break ADR-007's "exactly one bucket per artifact" invariant. As a lens it
+overlays all three buckets without partitioning them. Industry: Health is universally tracked but
+variably positioned — TAPPaaS chooses *lens* over *bucket* for prosumer UX. Evidence:
+[Architecture/taxonomy.md](<../Architecture/taxonomy.md>) → A.1.
+
+## Acceptance
+
+- [ ] Status badges defined for App / Environment / User.
+- [ ] One Site-level Health overview page in the UI mockup.

--- a/docs/ADR/ADR-009 - Composition Meta-Model.md
+++ b/docs/ADR/ADR-009 - Composition Meta-Model.md
@@ -1,0 +1,69 @@
+# ADR-009 — Composition Meta-Model
+
+| | |
+|---|---|
+| **Status** | Proposed — composition direction **pending #171** discussion |
+| **Version** | 0.1 |
+| **Date** | 2026-06-15 |
+| **Author** | Erik Daniel |
+| **Related** | **#171** (metamodel refine) · **#167** (component taxonomy) · #161, #151 (closed spikes) · #297 (catalog); **classification:** [ADR-007](<ADR-007 - TAPPaaS Taxonomy.md>); [Capabilities](<../Architecture/Capabilities.md>) + ArchiMate appendix |
+
+How a deployable unit is **built**. The companion to [ADR-007](<ADR-007 - TAPPaaS Taxonomy.md>):
+ADR-007 *classifies* (which bucket), this ADR *composes* (how it is structured). Orthogonal — apply both.
+
+> **Scope & status.** This ADR consolidates the #171 metamodel + the current docs. The **Node/Device
+> direction** is the one genuinely open point (Decision §1) and stays **Proposed pending #171** —
+> @larsrossen asked to keep #171 "smaller and more discussion-oriented", so the contested rename is a
+> discussion, not a fait accompli. The rest is data-verified and ready.
+
+## The model (ArchiMate-grounded)
+
+```
+Strategy:     Capability  ◁realizes◁  Stack  (Aggregation of Modules)
+Application:  Module ▷ Application Component (recursive) ▷ Application Function ▷ Application Service
+Technology:   Module (the VM)  ◁hosted-on◁  physical host (tappaas1)
+Artifact:     Implementation  →realizes→  Component/Module   (swappable)
+```
+
+Every **Module** is classified by exactly one ADR-007 bucket (+ `tier` + `source`). One model composes,
+the other classifies.
+
+## The divergence — three current sources disagree (live-verified 2026-06-15)
+
+| Concept | Capabilities.md + ArchiMate appendix (prose) | `module-fields.json` (schema/code) | #171 |
+|---|---|---|---|
+| **node** | a **VM** ("module runs on a NixOS VM = Node") | the **physical Proxmox host** (`node`, example `tappaas1`) | a **physical machine** (grounded in the schema, `tappaasN`) |
+| **Capability vs Service** | Module *implements a Capability* | uses the `capability` notation | uses **Service**, drops "capability" |
+| **Stack** | central (AI/Foundation Stack) | no `stack` field — absent | absent |
+| **Function / Implementation** | not present | (no field) | **new** |
+
+> **Verified:** "node = VM" is held only by **2 prose docs**; the **schema + #171 + tappaas.org's
+> foundation page** all use **node = physical host** — and ADR-007d's `site.json.hardware.nodes`
+> (`tappaas1`, `tappaas2`) does too. So "node = VM" is the minority; the code and #171 agree.
+
+## Decision
+
+1. **Node/Device — OPEN, pending #171.**
+   - **Option B (recommended)** — `node` = **physical host**, **Module = the VM** (what the code +
+     #171 + foundation page + ADR-007d already do; preserves "module boundary = VM boundary"). Fix
+     only the **2 prose docs** (appendix + Capabilities) to stop calling Node a VM.
+   - **Option A** — ArchiMate-pure: Node = VM, Device = physical (insert a VM-Node element). Higher
+     churn; contradicts the schema and #171.
+2. **Keep both Capability (Strategy) and Service (Application).** Rename the `module:capability`
+   notation → **`module:service`** (it is a Service).
+3. **Keep Stack** — an ArchiMate Aggregation of Modules realizing a Capability.
+4. **Component = Application Component** (recursive Composition).
+5. **Adopt Function + Implementation** (Application Function; Implementation = swappable Artifact).
+
+## Relation to the catalog/discovery axis (#297)
+
+The catalog (`module-catalog.json`, #297, already merged) carries `stack` × `category` × `repo` for
+**browsing** — a third, independent axis. ⚠️ **Naming collision:** `Stack` here (composition
+Aggregation) vs `stack` in #297 (a browse facet). **Recommendation:** rename the #297 facet
+`stack` → `domain`, reserving `Stack` for the Aggregation. (#297 is closed → needs a follow-up issue.)
+
+## Acceptance
+
+- [ ] #171 ratifies the Node/Device direction (Option B recommended).
+- [ ] Appendix + Capabilities.md updated to match (node = physical host); `capability` → `service`.
+- [ ] #297 `stack` → `domain` follow-up filed/decided.

--- a/docs/Architecture/Capabilities.md
+++ b/docs/Architecture/Capabilities.md
@@ -9,14 +9,15 @@ TAPPaaS is designed both top down and bottom up. Top down we looked at the capab
 We are trying to bring this together in a structured manner. This is a description of WHAT we want TAPPaaS to deliver. The HOW to deliver it is in the [SoftwareStack](TheSoftwareStack.md)
 
 > **Related models.** This document is the **strategy + structure** view (Stack → Capability →
-> Module). A **proposed composition meta-model** — `Node ▷ Module ▷ Component ▷ Function ▷ Service`
-> — is **issue #171**; it currently **diverges** from this document and the ArchiMate appendix on
-> `Node` (a VM here vs a physical machine in #171), on **`Capability` vs `Service`** (#171 replaces
-> capability with service — see #171 §10), and on **`Stack`** (used here, absent in #171).
-> Reconciliation is tracked on **issue #171**. Separately, the **classification** of each Module
-> (Site · People · Apps · Environments · Health + `tier`/`source`) is
-> **[ADR-007](<../ADR/ADR-007 - TAPPaaS Taxonomy.md>)** — orthogonal to whichever composition model
-> is ratified.
+> Module). The **composition meta-model** — `Stack ▷ Module ▷ Component ▷ Function ▷ Service` — is now
+> consolidated in **[ADR-009](<../ADR/ADR-009 - Composition Meta-Model.md>)** (tracking issue #171).
+> Note the open divergence ADR-009 records: this document/appendix call `Node` a **VM**, but the
+> schema (`module-fields.json`, `node` = `tappaas1`), #171, and the foundation design page all use
+> `node` = the **physical host** (with the **Module** as the VM). ADR-009 recommends aligning this
+> prose to *node = physical host*; `Capability` (Strategy) and `Service` (Application) are both kept.
+> Separately, the **classification** of each Module — one **Site** + 3 buckets (People · Apps ·
+> Environments) + **Health lens**, plus `tier`/`source` — is
+> **[ADR-007](<../ADR/ADR-007 - TAPPaaS Taxonomy.md>)**, orthogonal to the composition model.
 
 ## TAPPaaS high level structure
 

--- a/docs/Architecture/taxonomy.md
+++ b/docs/Architecture/taxonomy.md
@@ -1,0 +1,99 @@
+# TAPPaaS Taxonomy — Reference (worked example, sample files, evidence, glossary)
+
+> **Living reference, not a decision.** The decisions are in [ADR-007](<../ADR/ADR-007 - TAPPaaS Taxonomy.md>)
+> (overview) + 007a–007e + [ADR-009](<../ADR/ADR-009 - Composition Meta-Model.md>). This doc holds the
+> *current* tables, the worked example, ready-to-use sample files, and the industry evidence. Other
+> docs link here instead of restating the model.
+
+## The model at a glance
+
+**One Site** (container) → **3 buckets** (👥 People · 📦 Apps · 🏠 Environments) + **1 lens** (🩺 Health).
+
+## Worked example — SOHO setup
+
+A founder runs a household, a consulting company, contributes to TAPPaaS, and hosts one paying client,
+all on one physical Site:
+
+```
+🏢 Site: mysite-soho
+ ├ 👥 People
+ │   ├ Orgs:   myhome(family) · mybusiness-bv(company) · tappaas-org(foundation) · client-acme(customer→mybusiness-bv)
+ │   ├ Groups: myhome__family · mybusiness-bv__staff · tappaas-org__maintainers · client-acme__admins
+ │   └ Users:  <owner>(family+staff+maintainers) · person2..4(family)
+ ├ 🏠 Environments: myhome · mybusiness · tappaas · client-acme · dev   (each ownerOrg + zone + domain)
+ └ 📦 Apps
+     ├ foundation/official: firewall · cluster · identity · caddy · backup · tappaas-cicd
+     ├ app/official:        openwebui · vaultwarden · nextcloud · ...
+     ├ app/community:       some-cool-app
+     └ app/private:         consultancy-customer-portal
+```
+
+## Secrets — where they live
+
+| Secret type | Bucket | Stored |
+|---|---|---|
+| Personal credential | 👥 People | Authentik + Vaultwarden |
+| Workload secret | 📦 App | App-scoped store, `secretsRef` |
+| Infrastructure secret | 🏢 Site | `site.json` references, vault-managed |
+
+Rule: a secret belongs to the *thing that consumes it*; People-bucket RBAC decides who may read/change it.
+
+## Sample files (ready-to-use; replace placeholders)
+
+`site.json`, `people/organizations/*.json`, `people/groups/*.json`, `people/users/*.json`,
+`environments/*.json` — see the schema blocks in the corresponding sub-ADR (007a People, 007c
+Environments, 007d Site). Minimal `site.json`:
+
+```json
+{
+  "name": "mysite-soho", "displayName": "My SOHO", "owner": "<owner>",
+  "location": { "country": "NL", "timezone": "Europe/Amsterdam", "locale": "nl_NL" },
+  "network": { "rootDomain": "myhomedomain.nl" },
+  "hardware": { "nodes": ["tappaas1", "tappaas2"], "storagePools": ["tanka1", "tankb2"], "cluster": "tappaas" },
+  "identityProvider": { "type": "authentik", "url": "https://id.myhomedomain.nl" },
+  "backup": { "target": "backup.myhomedomain.nl", "offsite": "tappaas-backup-buddy" },
+  "updateChannel": "stable"
+}
+```
+
+## Appendix A — Industry evidence (data points)
+
+**A.1 — Top-level concepts across 18 platforms:** Identity/People 18/18; App/Workload 18/18;
+Environment 8/10; Project/Site 8/10; Health-as-separate-bucket 7/10 (variably positioned → TAPPaaS
+chooses *lens*). → justifies **People · Apps · Environments + Health lens**.
+
+**A.2 — Organization vs Tenant:** "Organization/Org" used by GCP, GitHub, Okta, Salesforce, HashiCorp,
+Google Workspace, Apple BM, AWS Orgs, Auth0, Microsoft = **10**; "Tenant" = 4 (architecture term only).
+
+**A.3 — Group vs Team:** 12/12 IAM systems (LDAP, AD, Authentik, Keycloak, AWS/Azure/GCP IAM, Okta,
+Auth0, Linux, K8s RBAC, Backstage) use **Group**. Group covers all 7 TAPPaaS use cases; Team does not.
+
+**A.4 — Comparable hierarchies:** Backstage Domain→System→Component; Coolify Server→Project→Env→Resource;
+Vercel Team→Project→Env; K8s Cluster→Namespace→Workload; UniFi Account→Site→Devices; AWS Org→Account→Resource;
+GCP Org→Folder→Project. TAPPaaS is intentionally flatter (Site → 3 buckets) for prosumer UX.
+
+**A.5 — "Environment" adoption:** de-facto term in every multi-env-capable platform (K8s, Coolify,
+Vercel, GCP/AWS/Azure, Heroku); single-env appliances (Synology, YunoHost, Umbrel, CasaOS) omit it.
+
+**A.6 — Multi-Org-on-one-host:** maps to cloud Organizations, MSP multi-tenant, holding-company IT,
+indie-hacker domains, Authentik/Keycloak realms. Common at enterprise scale, gap in prosumer FOSS.
+
+**A.7 — Source vs Tier:** 7/9 platforms (Debian, Ubuntu, HACS, Nextcloud, Synology, Umbrel, YunoHost)
+model curated-vs-community as **source**, separate from lifecycle **tier**. Both dimensions needed.
+
+## Appendix C — Glossary
+
+| Term | Definition |
+|---|---|
+| **Site** | The physical + admin perimeter. One TAPPaaS = one Site. |
+| **Organization** | A legal/identity entity (family, company, foundation, customer). Owns Envs + Apps. |
+| **Group** | A collection of Users for access control. Lives in one Org. The RBAC primitive. |
+| **User** | An individual human. Can be in many Groups across many Orgs. |
+| **Environment** | Where Apps run. Has zone, domain, update window. Owned by an Org. |
+| **App** | A workload (VM, container, service). Has a `tier` and a `source`. |
+| **Tier** | App lifecycle class: `foundation` (cannot uninstall) or `app` (user-installable). |
+| **Source** | App origin: `official` · `community` · `private` · `local`. |
+| **Health** | Cross-cutting observability lens. Not a bucket. |
+| **Tenant** | Architecture term for an isolated customer of a multi-tenant system. *Not* a UI term. |
+| **Node** | The physical Proxmox host (`tappaas1`). The VM is the **Module**. See ADR-009. |
+| **Module / Component / Function / Service / Stack** | Composition meta-model — see ADR-009. |


### PR DESCRIPTION
## Summary

Restructure the monolithic **ADR-007 v1.1** (1000+ lines) into a clear, **composable hierarchy — one
ADR per aspect** — with **ADR-007 as the overview** of the proposed model and the detail delegated to
underpinning sub-ADRs + **ADR-009** (composition). The *model is unchanged* from v1.1 (one **Site** +
3 buckets **People/Apps/Environments** + **Health lens**); only the structure changes, so each ADR is
easy to read and change on its own.

This also cleanly separates **classification** (ADR-007) from **composition** (ADR-009 / #171) — the
latter is what @larsrossen asked to keep small and discussion-oriented.

## What changed

| File | Change |
|------|--------|
| `ADR-007 - TAPPaaS Taxonomy.md` | → **overview** (v2.0): model, rationale, decision tree, context, risks, parking lot, consequences |
| `ADR-007a..e` | **new** — People · Apps (tier × source) · Environments · Site · Health (lens), one aspect each, with schemas |
| `ADR-009 - Composition Meta-Model.md` | **new** — consolidates #171; records the divergence + ArchiMate model |
| `Architecture/taxonomy.md` | **new** — living reference (worked example, sample files, industry evidence, glossary); preserves the v1.1 appendices |
| `Architecture/Capabilities.md` | align the related-models note → ADR-009 + node=physical |

## Key data-driven finding (in ADR-009)

`node` = the **physical Proxmox host** (`tappaas1`) is held by the schema (`module-fields.json`),
#171, the tappaas.org foundation page, **and** ADR-007d's `site.json.hardware.nodes`. Only **2 prose
docs** (Capabilities.md + the ArchiMate appendix) call Node a VM. ADR-009 recommends aligning the prose
to *node = physical host, Module = the VM* — the Node/Device direction stays **proposed pending #171**.

## Notes

- The model (3 buckets + Health lens) is **unchanged** from v1.1 — already the accepted direction.
- Composition decisions remain **proposed pending #171**; this PR documents and consolidates.
- Follow-up: rename the catalog `stack` facet → `domain` (#297, closed) to avoid colliding with the
  composition `Stack`.

## Issue references

Closes #320 · Refs #171, #167, #297, #183, #248, #318, #319, #294, #313