### PR TITLE
fix(identity): stage secrets merge through temp file (close 5b trunca…

### DIFF
--- a/src/foundation/identity/services/identity/install-service.sh
+++ b/src/foundation/identity/services/identity/install-service.sh
@@ -163,6 +163,10 @@ fi
 # 5b — merge-write: strip any prior OIDC_ lines, append new values. Preserves
 # co-managed keys (e.g. LITELLM_MASTER_KEY) that other services write to the
 # same secrets file (issue #369).
+# Stage through a temp file in the same dir and atomically mv into place: never
+# read and truncate the secrets file in one pipeline (a `grep file | tee file`
+# race could let tee truncate before grep reads, silently dropping the very
+# co-managed keys we mean to preserve). The merge runs in a single `sudo sh -c`.
 # A freshly (re)created VM reuses the hostname with a NEW host key; clear any
 # stale known_hosts entry first so StrictHostKeyChecking=accept-new doesn't reject
 # the CHANGED key (same approach as update-os.sh update_ssh_known_hosts).
@@ -172,10 +176,10 @@ ENV_CONTENT="$(printf 'OIDC_CLIENT_ID=%s\nOIDC_CLIENT_SECRET=%s\nOIDC_DISCOVERY_
     "${CLIENT_ID}" "${CLIENT_SECRET}" "${DISCOVERY_URI}")"
 if ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 "tappaas@${UPSTREAM}" \
     "sudo install -d -m 700 \"\$(dirname '${SECRETS_ENV}')\" && \
-     { if sudo test -f '${SECRETS_ENV}'; then sudo grep -v '^OIDC_' '${SECRETS_ENV}' || true; fi; \
-       printf '%s' \"${ENV_CONTENT}\"; } \
-     | sudo tee '${SECRETS_ENV}' >/dev/null && \
-     sudo chmod 600 '${SECRETS_ENV}'"; then
+     sudo sh -c 'umask 077; t=\$(mktemp \"\$(dirname \"${SECRETS_ENV}\")/.oidc.XXXXXX\") || exit 1; \
+       { [ -f \"${SECRETS_ENV}\" ] && grep -v \"^OIDC_\" \"${SECRETS_ENV}\"; \
+         printf \"%s\" \"${ENV_CONTENT}\"; } > \"\$t\" && \
+       chmod 600 \"\$t\" && mv -f \"\$t\" \"${SECRETS_ENV}\"'"; then
     info "  ${GN}✓${CL} merged OIDC vars into ${SECRETS_ENV}"
 else
     die "failed to write ${SECRETS_ENV} on ${UPSTREAM} (is the VM up and SSH reachable?)"


### PR DESCRIPTION
…tion race)

The merge-write in step 5b piped `grep SECRETS | tee SECRETS`, reading and truncating the same file in one pipeline. tee opens with O_TRUNC concurrently with grep, so on a lost race grep reads an already-empty file and the co-managed keys (e.g. LITELLM_MASTER_KEY) this change exists to preserve are silently dropped.

Do the merge in a single `sudo sh -c`: write existing non-OIDC lines plus the new OIDC vars to a mode-600 temp file in the same dir, then atomically mv it into place. No read+truncate of the live file; failure leaves the original untouched.