### PR TITLE
feat(tappaas-cicd): add gitleaks secret scanning host-wide

### DIFF
--- a/src/foundation/tappaas-cicd/tappaas-cicd.nix
+++ b/src/foundation/tappaas-cicd/tappaas-cicd.nix
@@ -282,7 +282,24 @@ in
         shellcheck   # bash script linting for module *.sh validation (#265)
         # OPNsense controller tools (opnsense-controller, opnsense-firewall, zone-manager, dns-manager)
         opnsenseController.default
+        # Secret scanning (#378) — system binary used by local pre-commit hooks.
+        # Avoids per-repo Go source downloads (17K files) that bloat ~/.cache.
+        gitleaks
+        pre-commit
   ];
+
+  # Global git template dir — every repo init/clone on this host auto-installs
+  # the gitleaks pre-commit hook. Per-repo .pre-commit-config.yaml uses
+  # `repo: local` to call the system binary; no source download ever needed.
+  # (#378)
+  programs.git.config = {
+    init.templateDir = "/etc/git-templates";
+  };
+
+  environment.etc."git-templates/hooks/pre-commit" = {
+    source = /home/tappaas/TAPPaaS/src/foundation/tappaas-cicd/templates/pre-commit-hook;
+    mode = "0755";
+  };
 
   # Enable automatic garbage collection
   nix.gc = {

--- a/src/foundation/tappaas-cicd/templates/pre-commit-config.yaml
+++ b/src/foundation/tappaas-cicd/templates/pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: gitleaks
+        name: gitleaks
+        entry: gitleaks protect --staged --redact
+        language: system
+        pass_filenames: false

--- a/src/foundation/tappaas-cicd/templates/pre-commit-hook
+++ b/src/foundation/tappaas-cicd/templates/pre-commit-hook
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Installed via git init.templateDir by tappaas-cicd NixOS config (#378).
+# Runs gitleaks on staged changes using the system binary — no source download.
+# Requires: gitleaks in PATH (provided by tappaas-cicd environment.systemPackages).
+set -euo pipefail
+
+if ! command -v gitleaks &>/dev/null; then
+  echo "gitleaks not found — skipping secret scan (install via NixOS systemPackages)" >&2
+  exit 0
+fi
+
+if [ -f .pre-commit-config.yaml ]; then
+  pre-commit run --hook-stage pre-commit
+else
+  gitleaks protect --staged --redact
+fi


### PR DESCRIPTION
## Summary

- Add `gitleaks` and `pre-commit` to `environment.systemPackages` — system binary, no per-repo Go source download or cache bloat (~17K files / 300MB avoided per cache-miss)
- Set `programs.git.config.init.templateDir` so every repo init/clone on this host auto-installs the hook — no manual per-repo setup
- Ship `templates/pre-commit-hook`: delegates to pre-commit when `.pre-commit-config.yaml` present, falls back to bare `gitleaks protect --staged`
- Ship `templates/pre-commit-config.yaml`: baseline `repo: local` config for new repos

## Test plan

- [ ] `gitleaks version` returns 8.28.0 on tappaas-cicd
- [ ] `which pre-commit` resolves to system binary
- [ ] `ls /etc/git-templates/hooks/pre-commit` exists and is executable
- [ ] `git init /tmp/test-repo && ls /tmp/test-repo/.git/hooks/pre-commit` — hook installed automatically
- [ ] Commit with a staged fake secret is blocked by the hook
- [ ] Commit without secrets passes

Closes #378